### PR TITLE
[WIP] Generalize types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,15 +27,15 @@ bench = true
 
 [dependencies]
 byteorder = "0.5"
-memmap = "0.4.0"
+memmap = "0.4"
 regex-syntax = "0.3"
 utf8-ranges = "0.1"
 
 [dev-dependencies]
-fnv = "1.0.3"
-lazy_static = "0.2.1"
-quickcheck = "0.3.1"
-rand = "0.3.14"
+fnv = "1.0"
+lazy_static = "0.2"
+quickcheck = "0.3"
+rand = "0.3"
 
 [profile.release]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,10 +32,10 @@ regex-syntax = "0.3"
 utf8-ranges = "0.1"
 
 [dev-dependencies]
-fnv = "1.0"
-lazy_static = "0.1"
-quickcheck = "0.2"
-rand = "0.3"
+fnv = "1.0.2"
+lazy_static = "0.2.1"
+quickcheck = "0.2.27"
+rand = "0.3.14"
 
 [profile.release]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,9 @@ regex-syntax = "0.3"
 utf8-ranges = "0.1"
 
 [dev-dependencies]
-fnv = "1.0.2"
+fnv = "1.0.3"
 lazy_static = "0.2.1"
-quickcheck = "0.2.27"
+quickcheck = "0.3.1"
 rand = "0.3.14"
 
 [profile.release]

--- a/src/algebra.rs
+++ b/src/algebra.rs
@@ -1,3 +1,5 @@
+use std::num::Wrapping;
+
 /// An abelian group; that is, a type `T` with the
 /// [functionally pure](https://en.wikipedia.org/wiki/Pure_function)
 /// methods `identity`, `plus`, and `minus` such that the following
@@ -10,7 +12,7 @@
 ///
 /// While this trait is already implemented for the common numeric types,
 /// it can also be implemented for other types in order to make those types
-/// usable as inputs to the finite state machines of this library.
+/// usable as outputs from the finite state machines of this library.
 pub trait AbelianGroup {
     /// The identity value of the abelian group.
     fn identity() -> Self;
@@ -22,98 +24,36 @@ pub trait AbelianGroup {
     fn minus(self, other: Self) -> Self;
 }
 
-impl AbelianGroup for u8 {
-    fn identity() -> u8 { 0 }
+macro_rules! numeric_abelian_group {
+    ($t:ty, $i:expr) => {
+        impl $crate::algebra::AbelianGroup for $t {
+            fn identity() -> $t { $i }
 
-    fn plus(self, other: u8) -> u8 { self + other }
+            fn plus(self, other: $t) -> $t { self + other }
 
-    fn minus(self, other: u8) -> u8 { self - other }
+            fn minus(self, other: $t) -> $t { self - other }
+        }
+    }
 }
-
-impl AbelianGroup for u16 {
-    fn identity() -> u16 { 0 }
-
-    fn plus(self, other: u16) -> u16 { self + other }
-
-    fn minus(self, other: u16) -> u16 { self - other }
-}
-
-impl AbelianGroup for u32 {
-    fn identity() -> u32 { 0 }
-
-    fn plus(self, other: u32) -> u32 { self + other }
-
-    fn minus(self, other: u32) -> u32 { self - other }
-}
-
-impl AbelianGroup for u64 {
-    fn identity() -> u64 { 0 }
-
-    fn plus(self, other: u64) -> u64 { self + other }
-
-    fn minus(self, other: u64) -> u64 { self - other }
-}
-
-impl AbelianGroup for usize {
-    fn identity() -> usize { 0 }
-
-    fn plus(self, other: usize) -> usize { self + other }
-
-    fn minus(self, other: usize) -> usize { self - other }
-}
-
-impl AbelianGroup for i8 {
-    fn identity() -> i8 { 0 }
-
-    fn plus(self, other: i8) -> i8 { self + other }
-
-    fn minus(self, other: i8) -> i8 { self - other }
-}
-
-impl AbelianGroup for i16 {
-    fn identity() -> i16 { 0 }
-
-    fn plus(self, other: i16) -> i16 { self + other }
-
-    fn minus(self, other: i16) -> i16 { self - other }
-}
-
-impl AbelianGroup for i32 {
-    fn identity() -> i32 { 0 }
-
-    fn plus(self, other: i32) -> i32 { self + other }
-
-    fn minus(self, other: i32) -> i32 { self - other }
-}
-
-impl AbelianGroup for i64 {
-    fn identity() -> i64 { 0 }
-
-    fn plus(self, other: i64) -> i64 { self + other }
-
-    fn minus(self, other: i64) -> i64 { self - other }
-}
-
-impl AbelianGroup for isize {
-    fn identity() -> isize { 0 }
-
-    fn plus(self, other: isize) -> isize { self + other }
-
-    fn minus(self, other: isize) -> isize { self - other }
-}
-
-impl AbelianGroup for f32 {
-    fn identity() -> f32 { 0.0 }
-
-    fn plus(self, other: f32) -> f32 { self + other }
-
-    fn minus(self, other: f32) -> f32 { self - other }
-}
-
-impl AbelianGroup for f64 {
-    fn identity() -> f64 { 0.0 }
-
-    fn plus(self, other: f64) -> f64 { self + other }
-
-    fn minus(self, other: f64) -> f64 { self - other }
-}
+numeric_abelian_group!(u8,0);
+numeric_abelian_group!(u16,0);
+numeric_abelian_group!(u32,0);
+numeric_abelian_group!(u64,0);
+numeric_abelian_group!(usize,0);
+numeric_abelian_group!(i8,0);
+numeric_abelian_group!(i16,0);
+numeric_abelian_group!(i32,0);
+numeric_abelian_group!(i64,0);
+numeric_abelian_group!(isize,0);
+numeric_abelian_group!(f32,0.0);
+numeric_abelian_group!(f64,0.0);
+numeric_abelian_group!(Wrapping<u8>,Wrapping(0));
+numeric_abelian_group!(Wrapping<u16>,Wrapping(0));
+numeric_abelian_group!(Wrapping<u32>,Wrapping(0));
+numeric_abelian_group!(Wrapping<u64>,Wrapping(0));
+numeric_abelian_group!(Wrapping<usize>,Wrapping(0));
+numeric_abelian_group!(Wrapping<i8>,Wrapping(0));
+numeric_abelian_group!(Wrapping<i16>,Wrapping(0));
+numeric_abelian_group!(Wrapping<i32>,Wrapping(0));
+numeric_abelian_group!(Wrapping<i64>,Wrapping(0));
+numeric_abelian_group!(Wrapping<isize>,Wrapping(0));

--- a/src/algebra.rs
+++ b/src/algebra.rs
@@ -1,0 +1,119 @@
+/// An abelian group; that is, a type `T` with the
+/// [functionally pure](https://en.wikipedia.org/wiki/Pure_function)
+/// methods `identity`, `plus`, and `minus` such that the following
+/// equations are obeyed:
+///
+/// - for all `x: T`, `y: T`, and `z: T`, `x.plus(y).plus(z) = x.plus(y.plus(z))`
+/// - for all `x: T` and `y: T`, `x.plus(y) = y.plus(x)`
+/// - for all `x: T`, `x.plus(T::identity()) = T::identity().plus(x) = x.minus(T::identity()) = x`
+/// - for all `x: T` and `y: T`, `x.plus(y).minus(y) = x.minus(y).plus(y) = x`
+///
+/// While this trait is already implemented for the common numeric types,
+/// it can also be implemented for other types in order to make those types
+/// usable as inputs to the finite state machines of this library.
+pub trait AbelianGroup {
+    /// The identity value of the abelian group.
+    fn identity() -> Self;
+
+    /// The addition operation of the abelian group.
+    fn plus(self, other: Self) -> Self;
+
+    /// The subtraction operation of the abelian group.
+    fn minus(self, other: Self) -> Self;
+}
+
+impl AbelianGroup for u8 {
+    fn identity() -> u8 { 0 }
+
+    fn plus(self, other: u8) -> u8 { self + other }
+
+    fn minus(self, other: u8) -> u8 { self - other }
+}
+
+impl AbelianGroup for u16 {
+    fn identity() -> u16 { 0 }
+
+    fn plus(self, other: u16) -> u16 { self + other }
+
+    fn minus(self, other: u16) -> u16 { self - other }
+}
+
+impl AbelianGroup for u32 {
+    fn identity() -> u32 { 0 }
+
+    fn plus(self, other: u32) -> u32 { self + other }
+
+    fn minus(self, other: u32) -> u32 { self - other }
+}
+
+impl AbelianGroup for u64 {
+    fn identity() -> u64 { 0 }
+
+    fn plus(self, other: u64) -> u64 { self + other }
+
+    fn minus(self, other: u64) -> u64 { self - other }
+}
+
+impl AbelianGroup for usize {
+    fn identity() -> usize { 0 }
+
+    fn plus(self, other: usize) -> usize { self + other }
+
+    fn minus(self, other: usize) -> usize { self - other }
+}
+
+impl AbelianGroup for i8 {
+    fn identity() -> i8 { 0 }
+
+    fn plus(self, other: i8) -> i8 { self + other }
+
+    fn minus(self, other: i8) -> i8 { self - other }
+}
+
+impl AbelianGroup for i16 {
+    fn identity() -> i16 { 0 }
+
+    fn plus(self, other: i16) -> i16 { self + other }
+
+    fn minus(self, other: i16) -> i16 { self - other }
+}
+
+impl AbelianGroup for i32 {
+    fn identity() -> i32 { 0 }
+
+    fn plus(self, other: i32) -> i32 { self + other }
+
+    fn minus(self, other: i32) -> i32 { self - other }
+}
+
+impl AbelianGroup for i64 {
+    fn identity() -> i64 { 0 }
+
+    fn plus(self, other: i64) -> i64 { self + other }
+
+    fn minus(self, other: i64) -> i64 { self - other }
+}
+
+impl AbelianGroup for isize {
+    fn identity() -> isize { 0 }
+
+    fn plus(self, other: isize) -> isize { self + other }
+
+    fn minus(self, other: isize) -> isize { self - other }
+}
+
+impl AbelianGroup for f32 {
+    fn identity() -> f32 { 0.0 }
+
+    fn plus(self, other: f32) -> f32 { self + other }
+
+    fn minus(self, other: f32) -> f32 { self - other }
+}
+
+impl AbelianGroup for f64 {
+    fn identity() -> f64 { 0.0 }
+
+    fn plus(self, other: f64) -> f64 { self + other }
+
+    fn minus(self, other: f64) -> f64 { self - other }
+}

--- a/src/algebra.rs
+++ b/src/algebra.rs
@@ -1,6 +1,8 @@
 use std::num::Wrapping;
 
-/// An abelian group; that is, a type `T` with the
+/// An [abelian group](https://ncatlab.org/nlab/show/abelian+group).
+///
+/// This is a type `T` with the
 /// [functionally pure](https://en.wikipedia.org/wiki/Pure_function)
 /// methods `identity`, `plus`, and `minus` such that the following
 /// equations are obeyed:

--- a/src/automaton/mod.rs
+++ b/src/automaton/mod.rs
@@ -135,7 +135,7 @@ impl Automaton for AlwaysMatch {
     fn accept(&self, _: &(), _: u8) -> () { () }
 }
 
-/// An automaton that matches and string that begins with something that the
+/// An automaton that matches any string that begins with something that the
 /// wrapped automaton matches.
 pub struct StartsWith<A>(A);
 

--- a/src/levenshtein/mod.rs
+++ b/src/levenshtein/mod.rs
@@ -134,6 +134,8 @@ impl DynamicLevenshtein {
 impl Automaton for Levenshtein {
     type State = Option<usize>;
 
+    type Token = u8;
+
     fn start(&self) -> Option<usize> { Some(0) }
 
     fn is_match(&self, state: &Option<usize>) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,3 +358,9 @@ pub mod map {
 pub mod set {
     pub use inner_set::*;
 }
+
+/// A module that contains definitions from abstract algebra that help this
+/// library's functionality.
+///
+/// The only type this module currently contains is `AbelianGroup`.
+pub mod algebra;

--- a/src/map.rs
+++ b/src/map.rs
@@ -555,7 +555,8 @@ impl<W: io::Write> MapBuilder<W> {
 /// The `'m` lifetime parameter refers to the lifetime of the underlying map.
 pub struct Stream<'m, A=AlwaysMatch>(raw::Stream<'m, A>) where A: Automaton;
 
-impl<'a, 'm, A: Automaton> Streamer<'a> for Stream<'m, A> {
+// FIXME: generalize from u8 to arbitrary tokens
+impl<'a, 'm, A: Automaton<Token = u8>> Streamer<'a> for Stream<'m, A> {
     type Item = (&'a [u8], u64);
 
     fn next(&'a mut self) -> Option<Self::Item> {
@@ -563,7 +564,8 @@ impl<'a, 'm, A: Automaton> Streamer<'a> for Stream<'m, A> {
     }
 }
 
-impl<'m, A: Automaton> Stream<'m, A> {
+// FIXME: generalize from u8 to arbitrary tokens
+impl<'m, A: Automaton<Token = u8>> Stream<'m, A> {
     /// Convert this stream into a vector of byte strings and outputs.
     ///
     /// Note that this creates a new allocation for every key in the stream.
@@ -667,7 +669,8 @@ impl<'m, A: Automaton> StreamBuilder<'m, A> {
     }
 }
 
-impl<'m, 'a, A: Automaton> IntoStreamer<'a> for StreamBuilder<'m, A> {
+// FIXME: generalize from u8 to arbitrary tokens
+impl<'m, 'a, A: Automaton<Token = u8>> IntoStreamer<'a> for StreamBuilder<'m, A> {
     type Item = (&'a [u8], u64);
     type Into = Stream<'m, A>;
 

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -429,7 +429,7 @@ impl Fst {
     /// Return a lexicographically ordered stream of all key-value pairs in
     /// this fst.
     pub fn stream(&self) -> Stream {
-        StreamBuilder::new(self, AlwaysMatch).into_stream()
+        StreamBuilder::new(self, AlwaysMatch::default()).into_stream()
     }
 
     /// Return a builder for range queries.
@@ -437,7 +437,7 @@ impl Fst {
     /// A range query returns a subset of key-value pairs in this fst in a
     /// range given in lexicographic order.
     pub fn range(&self) -> StreamBuilder {
-        StreamBuilder::new(self, AlwaysMatch)
+        StreamBuilder::new(self, AlwaysMatch::default())
     }
 
     /// Executes an automaton on the keys of this map.
@@ -551,7 +551,7 @@ impl<'a, 'f> IntoStreamer<'a> for &'f Fst {
     type Into = Stream<'f>;
 
     fn into_stream(self) -> Self::Into {
-        StreamBuilder::new(self, AlwaysMatch).into_stream()
+        StreamBuilder::new(self, AlwaysMatch::default()).into_stream()
     }
 }
 
@@ -609,7 +609,8 @@ impl<'f, A: Automaton> StreamBuilder<'f, A> {
     }
 }
 
-impl<'a, 'f, A: Automaton> IntoStreamer<'a> for StreamBuilder<'f, A> {
+// FIXME: generalize from u8 to arbitrary tokens
+impl<'a, 'f, A: Automaton<Token = u8>> IntoStreamer<'a> for StreamBuilder<'f, A> {
     type Item = (&'a [u8], Output);
     type Into = Stream<'f, A>;
 
@@ -673,7 +674,8 @@ struct StreamState<'f, S> {
     aut_state: S,
 }
 
-impl<'f, A: Automaton> Stream<'f, A> {
+// FIXME: generalize from u8 to arbitrary tokens
+impl<'f, A: Automaton<Token = u8>> Stream<'f, A> {
     fn new(fst: &'f Fst, aut: A, min: Bound, max: Bound) -> Self {
         let mut rdr = Stream {
             fst: fst,
@@ -839,7 +841,8 @@ impl<'f, A: Automaton> Stream<'f, A> {
     }
 }
 
-impl<'f, 'a, A: Automaton> Streamer<'a> for Stream<'f, A> {
+// FIXME: generalize from u8 to arbitrary tokens
+impl<'f, 'a, A: Automaton<Token = u8>> Streamer<'a> for Stream<'f, A> {
     type Item = (&'a [u8], Output);
 
     fn next(&'a mut self) -> Option<Self::Item> {

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -660,7 +660,7 @@ impl Bound {
 pub struct Stream<'f, A=AlwaysMatch> where A: Automaton {
     fst: &'f Fst,
     aut: A,
-    inp: Vec<u8>,
+    inp: Vec<A::Token>,
     empty_output: Option<Output>,
     stack: Vec<StreamState<'f, A::State>>,
     end_at: Bound,

--- a/src/raw/tests.rs
+++ b/src/raw/tests.rs
@@ -227,7 +227,7 @@ macro_rules! test_range {
                 items.into_iter().enumerate()
                      .map(|(i, k)| (k, i as u64)).collect();
             let fst = fst_map(items.clone());
-            let mut rdr = Stream::new(&fst, AlwaysMatch, $min, $max);
+            let mut rdr = Stream::new(&fst, AlwaysMatch::default(), $min, $max);
             for i in $imin..$imax {
                 assert_eq!(rdr.next().unwrap(),
                            (items[i].0.as_bytes(), Output::new(items[i].1)));

--- a/src/regex/compile.rs
+++ b/src/regex/compile.rs
@@ -1,4 +1,4 @@
-use regex_syntax::{Expr, Repeater, CharClass, ClassRange};
+use regex_syntax::{Expr, Repeater, CharClass, ByteClass, ClassRange, ByteRange};
 use utf8_ranges::{Utf8Sequences, Utf8Sequence};
 
 use regex::{Error, Inst};
@@ -57,15 +57,42 @@ impl Compiler {
                     }
                 }
             }
+            Expr::LiteralBytes { ref bytes, casei } => {
+                for &b in bytes {
+                    if casei {
+                        try!(self.c(&Expr::ClassBytes(ByteClass::new(vec![
+                            ByteRange { start: b, end: b },
+                        ]).case_fold())));
+                    } else {
+                        // One scalar value, so we're guaranteed to get a
+                        // single byte sequence.
+                        for seq in Utf8Sequences::new(b as char, b as char) {
+                            self.compile_utf8_ranges(&seq);
+                        }
+                    }
+                }
+            }
             Expr::AnyChar => try!(self.c(&Expr::Class(CharClass::new(vec![
                 ClassRange { start: '\u{0}', end: '\u{10FFFF}' },
+            ])))),
+            Expr::AnyByte => try!(self.c(&Expr::ClassBytes(ByteClass::new(vec![
+                ByteRange { start: 0x0u8, end: 0xFFu8 },
             ])))),
             Expr::AnyCharNoNL => try!(self.c(&Expr::Class(CharClass::new(vec![
                 ClassRange { start: '\u{0}', end: '\u{09}' },
                 ClassRange { start: '\u{0B}', end: '\u{10FFFF}' },
             ])))),
+            Expr::AnyByteNoNL => try!(self.c(&Expr::ClassBytes(ByteClass::new(vec![
+                ByteRange { start: 0x0u8, end: 0x09u8 },
+                ByteRange { start: 0x0Bu8, end: 0xFFu8 },
+            ])))),
             Expr::Class(ref cls) => {
                 try!(self.compile_class(cls));
+            }
+            Expr::ClassBytes(ref cls) => {
+                try!(self.compile_class(&CharClass::new(cls.into_iter().map(|rng| {
+                    ClassRange { start: rng.start as char, end: rng.end as char }
+                }).collect())));
             }
             Expr::Group { ref e, .. } => try!(self.c(e)),
             Expr::Concat(ref es) => {

--- a/src/regex/compile.rs
+++ b/src/regex/compile.rs
@@ -57,42 +57,15 @@ impl Compiler {
                     }
                 }
             }
-            Expr::LiteralBytes { ref bytes, casei } => {
-                for &b in bytes {
-                    if casei {
-                        try!(self.c(&Expr::ClassBytes(ByteClass::new(vec![
-                            ByteRange { start: b, end: b },
-                        ]).case_fold())));
-                    } else {
-                        // One scalar value, so we're guaranteed to get a
-                        // single byte sequence.
-                        for seq in Utf8Sequences::new(b as char, b as char) {
-                            self.compile_utf8_ranges(&seq);
-                        }
-                    }
-                }
-            }
             Expr::AnyChar => try!(self.c(&Expr::Class(CharClass::new(vec![
                 ClassRange { start: '\u{0}', end: '\u{10FFFF}' },
-            ])))),
-            Expr::AnyByte => try!(self.c(&Expr::ClassBytes(ByteClass::new(vec![
-                ByteRange { start: 0x0u8, end: 0xFFu8 },
             ])))),
             Expr::AnyCharNoNL => try!(self.c(&Expr::Class(CharClass::new(vec![
                 ClassRange { start: '\u{0}', end: '\u{09}' },
                 ClassRange { start: '\u{0B}', end: '\u{10FFFF}' },
             ])))),
-            Expr::AnyByteNoNL => try!(self.c(&Expr::ClassBytes(ByteClass::new(vec![
-                ByteRange { start: 0x0u8, end: 0x09u8 },
-                ByteRange { start: 0x0Bu8, end: 0xFFu8 },
-            ])))),
             Expr::Class(ref cls) => {
                 try!(self.compile_class(cls));
-            }
-            Expr::ClassBytes(ref cls) => {
-                try!(self.compile_class(&CharClass::new(cls.into_iter().map(|rng| {
-                    ClassRange { start: rng.start as char, end: rng.end as char }
-                }).collect())));
             }
             Expr::Group { ref e, .. } => try!(self.c(e)),
             Expr::Concat(ref es) => {

--- a/src/regex/mod.rs
+++ b/src/regex/mod.rs
@@ -126,6 +126,8 @@ impl Regex {
 impl Automaton for Regex {
     type State = Option<usize>;
 
+    type Token = u8;
+
     fn start(&self) -> Option<usize> { Some(0) }
 
     fn is_match(&self, state: &Option<usize>) -> bool {

--- a/src/set.rs
+++ b/src/set.rs
@@ -489,7 +489,8 @@ impl<W: io::Write> SetBuilder<W> {
 /// The `'s` lifetime parameter refers to the lifetime of the underlying set.
 pub struct Stream<'s, A=AlwaysMatch>(raw::Stream<'s, A>) where A: Automaton;
 
-impl<'s, A: Automaton> Stream<'s, A> {
+// FIXME: generalize from u8 to arbitrary tokens
+impl<'s, A: Automaton<Token = u8>> Stream<'s, A> {
     /// Creates a new set stream from an fst stream.
     ///
     /// Not part of the public API, but useful in sibling module `map`.
@@ -516,7 +517,8 @@ impl<'s, A: Automaton> Stream<'s, A> {
     }
 }
 
-impl<'a, 's, A: Automaton> Streamer<'a> for Stream<'s, A> {
+// FIXME: generalize from u8 to arbitrary tokens
+impl<'a, 's, A: Automaton<Token = u8>> Streamer<'a> for Stream<'s, A> {
     type Item = &'a [u8];
 
     fn next(&'a mut self) -> Option<Self::Item> {
@@ -560,7 +562,8 @@ impl<'s, A: Automaton> StreamBuilder<'s, A> {
     }
 }
 
-impl<'s, 'a, A: Automaton> IntoStreamer<'a> for StreamBuilder<'s, A> {
+// FIXME: generalize from u8 to arbitrary tokens
+impl<'s, 'a, A: Automaton<Token = u8>> IntoStreamer<'a> for StreamBuilder<'s, A> {
     type Item = &'a [u8];
     type Into = Stream<'s, A>;
 


### PR DESCRIPTION
**_NOTE:**_ _This pull request is a work in progress; it should not be merged until this message is removed._

The [article introducing `fst`](http://blog.burntsushi.net/transducers/) describes the conditions under which the theory behind this library holds.  Nonetheless, this library has been restricted to bytes and integers in practice.  This pull request aims to address these limitations by generalizing all types to accept any stream of totally ordered values (instead of just sequences of bytes) and any [_abelian group_](https://ncatlab.org/nlab/show/abelian+group) (instead of just integers).  The new type parameters will all be defaulted in such a way that existing source code should not have to be changed at all.
