### PR TITLE
added mmap feature (default on). 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ readme = "README.md"
 keywords = ["search", "information", "retrieval", "dictionary", "map"]
 license = "Unlicense/MIT"
 
+[features]
+mmap = ["memmap"]
+default = ["mmap"]
+
 [[bench]]
 name = "build"
 path = "./benches/build.rs"
@@ -25,9 +29,12 @@ path = "./benches/search.rs"
 test = false
 bench = true
 
+[dependencies.memmap]
+version = "0.4.0"
+optional = true
+
 [dependencies]
 byteorder = "0.5"
-memmap = "0.4.0"
 regex-syntax = "0.3"
 utf8-ranges = "0.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,12 +29,9 @@ path = "./benches/search.rs"
 test = false
 bench = true
 
-[dependencies.memmap]
-version = "0.4.0"
-optional = true
-
 [dependencies]
 byteorder = "0.5"
+mmap = { version = "0.4.0", optional = true }
 regex-syntax = "0.3"
 utf8-ranges = "0.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ bench = true
 
 [dependencies]
 byteorder = "0.5"
-mmap = { version = "0.4.0", optional = true }
+memmap = { version = "0.4.0", optional = true }
 regex-syntax = "0.3"
 utf8-ranges = "0.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,7 +281,7 @@ will be returned if the automaton gets too big (tens of MB in heap usage).
 #![deny(missing_docs)]
 
 extern crate byteorder;
-extern crate memmap;
+#[cfg(feature = "mmap")] extern crate memmap;
 #[cfg(test)] extern crate quickcheck;
 #[cfg(test)] extern crate rand;
 extern crate regex_syntax;

--- a/src/map.rs
+++ b/src/map.rs
@@ -62,6 +62,7 @@ impl Map {
     /// transducer builder (`MapBuilder` qualifies). If the format is invalid
     /// or if there is a mismatch between the API version of this library
     /// and the map, then an error is returned.
+    #[cfg(feature = "mmap")]
     pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self> {
         raw::Fst::from_path(path).map(Map)
     }

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -34,7 +34,7 @@ use stream::{IntoStreamer, Streamer};
 pub use self::build::Builder;
 pub use self::error::Error;
 pub use self::node::{Node, Transitions};
-pub use self::mmap::MmapReadOnly;
+#[cfg(feature = "mmap")] pub use self::mmap::MmapReadOnly;
 use self::node::node_new;
 pub use self::ops::{
     IndexedValue, OpBuilder,
@@ -45,7 +45,7 @@ mod build;
 mod common_inputs;
 mod counting_writer;
 mod error;
-mod mmap;
+#[cfg(feature = "mmap")] mod mmap;
 mod node;
 mod ops;
 mod pack;
@@ -288,6 +288,7 @@ impl Fst {
     /// transducer builder (`Builder` qualifies). If the format is invalid or
     /// if there is a mismatch between the API version of this library and the
     /// fst, then an error is returned.
+    #[cfg(feature = "mmap")] 
     pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self> {
         Fst::from_mmap(try!(MmapReadOnly::open_path(path)))
     }
@@ -297,6 +298,7 @@ impl Fst {
     /// This is useful if a transducer is serialized to only a part of a file.
     /// A `MmapReadOnly` lets one control which region of the file is used for
     /// the transducer.
+    #[cfg(feature = "mmap")]
     pub fn from_mmap(mmap: MmapReadOnly) -> Result<Self> {
         Fst::new(FstData::Mmap(mmap))
     }
@@ -958,6 +960,7 @@ enum FstData {
         offset: usize,
         len: usize,
     },
+    #[cfg(feature = "mmap")]
     Mmap(MmapReadOnly),
 }
 
@@ -970,6 +973,7 @@ impl Deref for FstData {
             FstData::Shared { ref vec, offset, len } => {
                 &vec[offset..offset + len]
             }
+            #[cfg(feature = "mmap")]
             FstData::Mmap(ref v) => unsafe { v.as_slice() },
         }
     }

--- a/src/set.rs
+++ b/src/set.rs
@@ -37,6 +37,7 @@ impl Set {
     /// transducer builder (`SetBuilder` qualifies). If the format is invalid
     /// or if there is a mismatch between the API version of this library
     /// and the set, then an error is returned.
+    #[cfg(feature = "mmap")]
     pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self> {
         raw::Fst::from_path(path).map(Set)
     }


### PR DESCRIPTION
Allows to disable memmap dependency when no filesystem is avaible.

(required to build for wasm/asmjs)