### PR TITLE
&& should be an ||.

### DIFF
--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -382,7 +382,7 @@ impl Fst {
         //
         // This is essentially our own little checksum.
         if (root_addr == EMPTY_ADDRESS && data.len() != 32)
-            && root_addr + 17 != data.len() {
+            || root_addr + 17 != data.len() {
             return Err(Error::Format.into());
         }
         Ok(Fst {


### PR DESCRIPTION
&& in this case doesn't make sense since if that were the case, root_addr would be constant (0) and data.len() can't be less than 32 anyways.

The first line is checking the empty FST case and the second line is checking the non-empty case, so they should be or'd.