### PR TITLE
add get_ref(), bytes_written() to MapBuilder (#23)

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -546,6 +546,17 @@ impl<W: io::Write> MapBuilder<W> {
     pub fn into_inner(self) -> Result<W> {
         self.0.into_inner()
     }
+
+    /// Gets a reference to the underlying writer.
+    pub fn get_ref(&self) -> &W {
+        self.0.get_ref()
+    }
+
+    /// Returns the number of bytes written to the underlying writer
+    pub fn bytes_written(&self) -> u64 {
+        self.0.bytes_written()
+    }
+
 }
 
 /// A lexicographically ordered stream of key-value pairs from a map.

--- a/src/raw/build.rs
+++ b/src/raw/build.rs
@@ -291,6 +291,16 @@ impl<W: io::Write> Builder<W> {
         }
         Ok(())
     }
+
+    /// Gets a reference to the underlying writer.
+    pub fn get_ref(&self) -> &W {
+        self.wtr.get_ref()
+    }
+
+    /// Returns the number of bytes written to the underlying writer
+    pub fn bytes_written(&self) -> u64 {
+        self.wtr.count()
+    }
 }
 
 impl UnfinishedNodes {

--- a/src/raw/counting_writer.rs
+++ b/src/raw/counting_writer.rs
@@ -27,6 +27,12 @@ impl<W: io::Write> CountingWriter<W> {
     pub fn into_inner(self) -> W {
         self.wtr
     }
+
+    /// Gets a reference to the underlying writer.
+    pub fn get_ref(&self) -> &W {
+        &self.wtr
+    }
+
 }
 
 impl<W: io::Write> io::Write for CountingWriter<W> {

--- a/src/raw/tests.rs
+++ b/src/raw/tests.rs
@@ -494,3 +494,15 @@ fn one_vec_multiple_fsts() {
     assert_eq!(fst_inputs(&fst1), vec![b"bar".to_vec(), b"baz".to_vec()]);
     assert_eq!(fst_inputs(&fst2), vec![b"bar".to_vec(), b"foo".to_vec()]);
 }
+
+#[test]
+fn bytes_written() {
+    let mut bfst1 = Builder::memory();
+    bfst1.add(b"bar").unwrap();
+    bfst1.add(b"baz").unwrap();
+    let counted_len = bfst1.bytes_written();
+    let bytes = bfst1.into_inner().unwrap();
+    let fst1_len = bytes.len() as u64;
+    let footer_size = 24;
+    assert_eq!(counted_len + footer_size, fst1_len);
+}

--- a/src/set.rs
+++ b/src/set.rs
@@ -480,6 +480,17 @@ impl<W: io::Write> SetBuilder<W> {
     pub fn into_inner(self) -> Result<W> {
         self.0.into_inner()
     }
+
+    /// Gets a reference to the underlying writer.
+    pub fn get_ref(&self) -> &W {
+        self.0.get_ref()
+    }
+
+    /// Returns the number of bytes written to the underlying writer
+    pub fn bytes_written(&self) -> u64 {
+        self.0.bytes_written()
+    }
+
 }
 
 /// A lexicographically ordered stream of keys from a set.


### PR DESCRIPTION
Feedback welcome!
While the `get_ref()` code is fairly simple, I would still like to write a test. Any ideas how to that while keeping the borrow checker happy?

I also don't like the magic footer size constant in the `bytes_written` test, but haven't found a decent way around that.

I omitted a `get_mut` implementation, because IMHO this might be a bit of a footgun, allowing corruption of the fst stream.