### PR TITLE
Update memmap dependency to fix API incompatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ bench = true
 
 [dependencies]
 byteorder = "1"
-memmap = { version = "0.4.0", optional = true }
+memmap = { version = "0.5", optional = true }
 
 [dev-dependencies]
 fnv = "1.0.5"
@@ -39,7 +39,7 @@ fst-levenshtein = { version = "0.1", path = "fst-levenshtein" }
 fst-regex = { version = "0.1", path = "fst-regex" }
 lazy_static = "0.2.8"
 quickcheck = { version = "0.4.1", default-features = false }
-rand = "0.3.15"
+rand = "0.3.16"
 
 [profile.release]
 debug = true

--- a/src/raw/build.rs
+++ b/src/raw/build.rs
@@ -265,7 +265,7 @@ impl<W: io::Write> Builder<W> {
         let start_addr = self.wtr.count() as CompiledAddr;
         try!(node.compile_to(&mut self.wtr, self.last_addr, start_addr));
         self.last_addr = self.wtr.count() as CompiledAddr - 1;
-        if let RegistryEntry::NotFound(mut cell) = entry {
+        if let RegistryEntry::NotFound(cell) = entry {
             cell.insert(self.last_addr);
         }
         Ok(self.last_addr)


### PR DESCRIPTION
The proper fix(in case the `memmap` API still has to be exposed) for this would probably be to re-export the `memmap` API from `fst`(basically push it up the chain, thus everybody that uses `fst` directly or indirectly have to stick to the same `memmap` version :( ) but I didn't want to take that decision for the project.

The problem is that `fst` exposes the `memmap` API, through its own API(ex: `impl From<Mmap>...`).
`memmap 0.5` in theory is a breaking API change, so Rust doesn't allow other projects depending on `fst` to update to `memmap 0.5`.

I think this also needs a version bump to `0.3.0`(`fst` version).