### PR TITLE
Make enough member fields public to make it possible to implement search(...) externally

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -54,7 +54,7 @@ use Result;
 /// Keys will always be byte strings; however, we may grow more conveniences
 /// around dealing with them (such as a serialization/deserialization step,
 /// although it isn't clear where exactly this should live).
-pub struct Map(raw::Fst);
+pub struct Map(pub raw::Fst);
 
 impl Map {
     /// Opens a map stored at the given file path via a memory map.

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -277,7 +277,8 @@ pub type CompiledAddr = usize;
 ///   (excellent for surface level overview)
 pub struct Fst {
     data: FstData,
-    root_addr: CompiledAddr,
+    /// The address of the root note in the transducer
+    pub root_addr: CompiledAddr,
     ty: FstType,
     len: usize,
 }


### PR DESCRIPTION
Further to https://github.com/BurntSushi/fst/issues/43

After having worked on this a bit more, I think it would be easiest for me if I could implement variations of search(...) externally. This would allow others to use different search strategies for different situations. (It has become clear to me that this is the next step for me own project.) You can see the external implementation of the original requested change discussed in the issue at https://github.com/frankier/fst-extra-aut/tree/fst-ext/src/ext

For this to be possible a couple of extra fields need to be made public.