### PR TITLE
Update to memmap 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ bench = true
 
 [dependencies]
 byteorder = "1"
-memmap = { version = "0.4.0", optional = true }
+memmap = "0.6"
 
 [dev-dependencies]
 fnv = "1.0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ try!(build.finish());
 // At this point, the map has been constructed. Now we'd like to search it.
 // This creates a memory map, which enables searching the map without loading
 // all of it into memory.
-let map = try!(Map::from_path("map.fst"));
+let map = try!(unsafe { Map::from_path("map.fst") });
 
 // Query for keys that are greater than or equal to clarence.
 let mut stream = map.range().ge("clarence").into_stream();

--- a/src/map.rs
+++ b/src/map.rs
@@ -64,7 +64,7 @@ impl Map {
     /// or if there is a mismatch between the API version of this library
     /// and the map, then an error is returned.
     #[cfg(feature = "mmap")]
-    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self> {
+    pub unsafe fn from_path<P: AsRef<Path>>(path: P) -> Result<Self> {
         raw::Fst::from_path(path).map(Map)
     }
 
@@ -476,7 +476,7 @@ impl<'m, 'a> IntoStreamer<'a> for &'m Map {
 /// build.finish().unwrap();
 ///
 /// // At this point, the map has been constructed, but here's how to read it.
-/// let map = Map::from_path("map.fst").unwrap();
+/// let map = unsafe { Map::from_path("map.fst").unwrap() };
 /// let mut stream = map.into_stream();
 /// let mut kvs = vec![];
 /// while let Some((k, v)) = stream.next() {

--- a/src/raw/mmap.rs
+++ b/src/raw/mmap.rs
@@ -3,7 +3,7 @@ use std::io;
 use std::path::Path;
 use std::sync::Arc;
 
-use memmap::{Mmap, Protection};
+use memmap::Mmap;
 
 /// A read only view into a memory map.
 ///
@@ -22,12 +22,12 @@ pub struct MmapReadOnly {
 
 impl MmapReadOnly {
     /// Create a new memory map from an existing file handle.
-    pub fn open(file: &fs::File) -> io::Result<MmapReadOnly> {
-        Ok(try!(Mmap::open(file, Protection::Read)).into())
+    pub unsafe fn open(file: &fs::File) -> io::Result<MmapReadOnly> {
+        Ok(try!(Mmap::map(file)).into())
     }
 
     /// Open a new memory map from the path given.
-    pub fn open_path<P: AsRef<Path>>(path: P) -> io::Result<MmapReadOnly> {
+    pub unsafe fn open_path<P: AsRef<Path>>(path: P) -> io::Result<MmapReadOnly> {
         MmapReadOnly::open(&try!(fs::File::open(path)))
     }
 
@@ -52,8 +52,8 @@ impl MmapReadOnly {
     }
 
     /// Read the memory map as a `&[u8]`.
-    pub unsafe fn as_slice(&self) -> &[u8] {
-        &self.map.as_slice()[self.offset..self.offset + self.len]
+    pub fn as_slice(&self) -> &[u8] {
+        &self.map[self.offset..self.offset + self.len]
     }
 }
 

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -290,7 +290,7 @@ impl Fst {
     /// if there is a mismatch between the API version of this library and the
     /// fst, then an error is returned.
     #[cfg(feature = "mmap")]
-    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self> {
+    pub unsafe fn from_path<P: AsRef<Path>>(path: P) -> Result<Self> {
         Fst::from_mmap(try!(MmapReadOnly::open_path(path)))
     }
 
@@ -980,7 +980,7 @@ impl Deref for FstData {
                 &vec[offset..offset + len]
             }
             #[cfg(feature = "mmap")]
-            FstData::Mmap(ref v) => unsafe { v.as_slice() },
+            FstData::Mmap(ref v) => v.as_slice(),
         }
     }
 }

--- a/src/set.rs
+++ b/src/set.rs
@@ -39,7 +39,7 @@ impl Set {
     /// or if there is a mismatch between the API version of this library
     /// and the set, then an error is returned.
     #[cfg(feature = "mmap")]
-    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self> {
+    pub unsafe fn from_path<P: AsRef<Path>>(path: P) -> Result<Self> {
         raw::Fst::from_path(path).map(Set)
     }
 
@@ -425,7 +425,7 @@ impl From<raw::Fst> for Set {
 /// build.finish().unwrap();
 ///
 /// // At this point, the set has been constructed, but here's how to read it.
-/// let set = Set::from_path("set.fst").unwrap();
+/// let set = unsafe { Set::from_path("set.fst").unwrap() };
 /// let mut stream = set.into_stream();
 /// let mut keys = vec![];
 /// while let Some(key) = stream.next() {


### PR DESCRIPTION
`memmap` 0.6.0 introduces major API changes in anticipation of a 1.0
release. See https://github.com/danburkert/memmap-rs/releases/tag/0.6.0
for more information. CC danburkert/memmap-rs#33.

Note: since `memmap` is a public dependency of `fst` I had to take some
liberties with modifying public interfaces. You probably don't want to
land this PR as is, however I think it will be a useful example for when
the time comes to move to the new `memmap` API internally.