### PR TITLE
Updates README Cargo.toml example to say 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Simply add a corresponding entry to your `Cargo.toml` dependency list:
 
 ```toml,ignore
 [dependencies]
-fst = "0.2"
+fst = "0.3"
 ```
 
 And add this to your crate root:


### PR DESCRIPTION
This is the latest version of the fst crate, and is what is mentioned in the next paragraph.