### PR TITLE
Add a StreamWithState streamer

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -632,6 +632,22 @@ impl<'m, A: Automaton> Stream<'m, A> {
     }
 }
 
+/// A lexicographically ordered stream of key-value from a map
+/// along with the states of the automaton.
+///
+/// The `Stream` type is based on the `StreamWithState`.
+pub struct StreamWithState<'m, A=AlwaysMatch>(raw::StreamWithState<'m, A>) where A: Automaton;
+
+impl<'a, 'm, A: 'a + Automaton> Streamer<'a> for StreamWithState<'m, A>
+where A::State: Clone
+{
+    type Item = (&'a [u8], u64, A::State);
+
+    fn next(&'a mut self) -> Option<Self::Item> {
+        self.0.next().map(|(key, out, state)| (key, out.value(), state))
+    }
+}
+
 /// A lexicographically ordered stream of keys from a map.
 ///
 /// The `'m` lifetime parameter refers to the lifetime of the underlying map.
@@ -693,6 +709,12 @@ impl<'m, A: Automaton> StreamBuilder<'m, A> {
     pub fn lt<T: AsRef<[u8]>>(self, bound: T) -> Self {
         StreamBuilder(self.0.lt(bound))
     }
+
+    /// Return this builder and gives the automaton states
+    /// along with the results.
+    pub fn with_state(self) -> StreamWithStateBuilder<'m, A> {
+        StreamWithStateBuilder(self.0.with_state())
+    }
 }
 
 impl<'m, 'a, A: Automaton> IntoStreamer<'a> for StreamBuilder<'m, A> {
@@ -701,6 +723,32 @@ impl<'m, 'a, A: Automaton> IntoStreamer<'a> for StreamBuilder<'m, A> {
 
     fn into_stream(self) -> Self::Into {
         Stream(self.0.into_stream())
+    }
+}
+
+/// A builder for constructing range queries of streams
+/// that returns results along with automaton states.
+///
+/// Once all bounds are set, one should call `into_stream` to get a
+/// `StreamWithState`.
+///
+/// Bounds are not additive. That is, if `ge` is called twice on the same
+/// builder, then the second setting wins.
+///
+/// The `A` type parameter corresponds to an optional automaton to filter
+/// the stream. By default, no filtering is done.
+///
+/// The `'m` lifetime parameter refers to the lifetime of the underlying map.
+pub struct StreamWithStateBuilder<'m, A=AlwaysMatch>(raw::StreamWithStateBuilder<'m, A>);
+
+impl<'m, 'a, A: 'a + Automaton> IntoStreamer<'a> for StreamWithStateBuilder<'m, A>
+where A::State: Clone
+{
+    type Item = (&'a [u8], u64, A::State);
+    type Into = StreamWithState<'m, A>;
+
+    fn into_stream(self) -> Self::Into {
+        StreamWithState(self.0.into_stream())
     }
 }
 


### PR DESCRIPTION
This is an attempt to be able to retrieve the `Automaton` `State` from a streamer, this streamer will be called `StreamWithState`.

Currently the [`map::Stream`](https://docs.rs/fst/0.3.1/fst/map/struct.Stream.html) struct implement the [`Streamer`](https://docs.rs/fst/0.3.1/fst/trait.Streamer.html) trait with an associated `Streamer::Item` that is `(&[u8], u64)` in other term the _matching string_ associated with the _value_.

The problem is that it is not possible to retrieve the state of the automaton with the current `map::Stream` type. It could be useful when the `map::Stream` is used with a levenshtein automaton, the state will permit to know the distance of the _matching string_ returned.

So I propose to add a new struct named `StreamWithState` that implement the `Streamer` trait and its associated type `Streamer::Item` is `(&[u8], u64, A::State)` where `A: Automaton`. This way the user will be able to retrieve the state of the [`Automaton`](https://docs.rs/fst/0.3.1/fst/trait.Automaton.html) and therefore the levenshtein distance of the _matching string_ returned (by answering the automaton).

The `StreamWithState` is accessible via the `with_state` self consuming method on [`map::StreamBuilder`](https://docs.rs/fst/0.3.1/fst/map/struct.StreamBuilder.html).

All of this resolves #60.

What I have done here is probably a little bit confused due to the way github shows the diffs.
For me, `map::StreamWithState` is a superset of `raw::Stream` [It should be possible to implement `map::Stream` using the other](https://github.com/BurntSushi/fst/pull/61/files#diff-1b47db5c9a30eca8cfa833e56ecf2c4eR718) and just ignoring the `Automaton::State`, so I created [a special `StreamWithState::next` method](https://github.com/BurntSushi/fst/pull/61/files#diff-1b47db5c9a30eca8cfa833e56ecf2c4eR932) that accept a function which will "transform" the `A::State`:
  - the `map::Stream` which does not need the state, ignores it [by using a function that return `()`](https://github.com/BurntSushi/fst/pull/61/files#diff-1b47db5c9a30eca8cfa833e56ecf2c4eR791).
  - and the `map::StreamWithState` clones it [by using the `Clone::clone` function](https://github.com/BurntSushi/fst/pull/61/files#diff-1b47db5c9a30eca8cfa833e56ecf2c4eR988).