### PR TITLE
Implement `Default` for Set and Map

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::iter::FromIterator;
+use std::iter::{self, FromIterator};
 use std::io;
 #[cfg(feature = "mmap")]
 use std::path::Path;
@@ -358,6 +358,12 @@ impl Map {
     /// Returns a reference to the underlying raw finite state transducer.
     pub fn as_fst(&self) -> &raw::Fst {
         &self.0
+    }
+}
+
+impl Default for Map {
+    fn default() -> Map {
+        Map::from_iter(iter::empty::<(&[u8], u64)>()).unwrap()
     }
 }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::iter::FromIterator;
+use std::iter::{self, FromIterator};
 use std::io;
 #[cfg(feature = "mmap")]
 use std::path::Path;
@@ -311,6 +311,12 @@ impl Set {
     /// Returns a reference to the underlying raw finite state transducer.
     pub fn as_fst(&self) -> &raw::Fst {
         &self.0
+    }
+}
+
+impl Default for Set {
+    fn default() -> Set {
+        Set::from_iter(iter::empty::<&[u8]>()).unwrap()
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -137,3 +137,12 @@ fn union_large() {
     }
     assert_eq!(stream2.next(), None);
 }
+
+#[test]
+fn implements_default() {
+    let map: fst::Map = Default::default();
+    assert!(map.is_empty());
+
+    let set: fst::Set = Default::default();
+    assert!(set.is_empty());
+}


### PR DESCRIPTION
What do you think about adding `Default` for map & set?

On the one hand, `Default` does not really make sense, because fsts are immutable once created. On the other hand, the APIs which use two-phase construction exist (i.e, the recent PR to rls-analysis), and for them having a default is handy.