### PR TITLE
Add Subsequence automaton

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -6,6 +6,7 @@ use fst_levenshtein::Levenshtein;
 use fst_regex::Regex;
 
 use fst::{Automaton, IntoStreamer, Streamer};
+use fst::automaton::Subsequence;
 use fst::raw::{Builder, Fst, Output};
 use fst::set::{Set, OpBuilder};
 
@@ -132,6 +133,19 @@ fn union_large() {
         .add(set.search(&lev))
         .add(set.search(&reg))
         .union();
+    while let Some(key1) = stream1.next() {
+        assert_eq!(stream2.next(), Some(key1));
+    }
+    assert_eq!(stream2.next(), None);
+}
+
+#[test]
+fn subsequence() {
+    let set = get_set();
+    let subseq = Subsequence::new("aab");
+    let regex = Regex::new(".*a.*a.*b.*").unwrap();
+    let mut stream1 = set.search(&subseq).into_stream();
+    let mut stream2 = set.search(&regex).into_stream();
     while let Some(key1) = stream1.next() {
         assert_eq!(stream2.next(), Some(key1));
     }


### PR DESCRIPTION
Adds a simple `Subsequece` automaton as an example. 

On the one hand, this seems like a random addition of a specific case.

On the other hand, subsequence search is actually good in practice for fuzzy-finders and such. This might also serve as a good example of how to implement your own `Automaton`: it is more concrete that abstract algebraic combinators, and simpler than Levenstein. 