### PR TITLE
deps: update various dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,7 @@ rust:
   - stable
   - beta
   - nightly
-script:
-  - cargo build --verbose
-  - cargo build --verbose --manifest-path fst-bin/Cargo.toml
-  - cargo doc
-  - cargo test --verbose
-  - cargo test --lib --no-default-features
-  - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
-      cargo bench --verbose --no-run;
-    fi
+script: ci/script.sh
+branches:
+  only:
+    - master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fst"
-version = "0.3.0"  #:version
+version = "0.3.1"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = """
 Use finite state transducers to compactly represents sets or maps of many
 strings (> 1 billion is possible).
 """
-documentation = "http://burntsushi.net/rustdoc/fst/"
+documentation = "https://docs.rs/fst"
 homepage = "https://github.com/BurntSushi/fst"
 repository = "https://github.com/BurntSushi/fst"
 readme = "README.md"
@@ -35,11 +35,11 @@ memmap = { version = "0.6.0", optional = true }
 
 [dev-dependencies]
 fnv = "1.0.5"
-fst-levenshtein = { version = "0.2", path = "fst-levenshtein" }
-fst-regex = { version = "0.2", path = "fst-regex" }
+fst-levenshtein = { version = "0.2.1", path = "fst-levenshtein" }
+fst-regex = { version = "0.2.1", path = "fst-regex" }
 lazy_static = "0.2.8"
-quickcheck = { version = "0.4.1", default-features = false }
-rand = "0.3.15"
+quickcheck = { version = "0.7", default-features = false }
+rand = "0.5"
 
 [profile.release]
 debug = true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,22 @@
 environment:
   matrix:
-  - TARGET: x86_64-pc-windows-msvc
+  - TARGET: x86_64-pc-windows-gnu
+    BITS: 64
+    MSYS2: 1
   - TARGET: i686-pc-windows-gnu
+    BITS: 32
+    MSYS2: 1
 install:
-  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
-  - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
-  - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
-  - SET PATH=%PATH%;C:\MinGW\bin
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs/
+  - rustup-init.exe -y --default-host %TARGET%
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - if defined MSYS2 set PATH=C:\msys64\mingw%BITS%\bin;%PATH%
   - rustc -V
   - cargo -V
-
 build: false
-
 test_script:
-  - cargo build --verbose
-  - cargo test --verbose
+  - cargo build --verbose --all
+  - cargo test --verbose --all
+branches:
+  only:
+    - master

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -ex
+
+cargo doc --verbose
+cargo build --verbose
+cargo build --verbose --manifest-path fst-bin/Cargo.toml
+
+# If we're testing on an older version of Rust, then only check that we
+# can build the crate. This is because the dev dependencies might be updated
+# more frequently, and therefore might require a newer version of Rust.
+#
+# This isn't ideal. It's a compromise.
+if [ "$TRAVIS_RUST_VERSION" = "1.20.0" ]; then
+  exit
+fi
+
+cargo test --verbose
+cargo test --verbose  --lib --no-default-features
+if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
+  cargo bench --verbose --no-run
+fi

--- a/fst-levenshtein/Cargo.toml
+++ b/fst-levenshtein/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fst-levenshtein"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = """
 Search finite state transducers with fuzzy queries using Levenshtein automata.
@@ -12,5 +12,5 @@ keywords = ["search", "information", "retrieval", "dictionary", "map"]
 license = "Unlicense/MIT"
 
 [dependencies]
-fst = { path = "..", version = "0.3" }
-utf8-ranges = "0.1"
+fst = { path = "..", version = "0.3.1" }
+utf8-ranges = "1"

--- a/fst-regex/Cargo.toml
+++ b/fst-regex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fst-regex"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = """
 Search finite state transducers with regular expression.
@@ -12,6 +12,6 @@ keywords = ["search", "information", "retrieval", "dictionary", "map"]
 license = "Unlicense/MIT"
 
 [dependencies]
-fst = { path = "..", version = "0.3" }
+fst = { path = "..", version = "0.3.1" }
 regex-syntax = "0.3"
-utf8-ranges = "0.1"
+utf8-ranges = "1"


### PR DESCRIPTION
We retain our minimum Rust version of 1.20.0, but we now only test the
crate on stable/beta/nightly (we only ensure it builds on Rust 1.20.0).