### PR TITLE
add #[inline] to public non-generic functions

### DIFF
--- a/fst-levenshtein/src/lib.rs
+++ b/fst-levenshtein/src/lib.rs
@@ -89,6 +89,7 @@ impl Levenshtein {
     ///
     /// A `Levenshtein` value satisfies the `Automaton` trait, which means it
     /// can be used with the `search` method of any finite state transducer.
+    #[inline]
     pub fn new(query: &str, distance: u32) -> Result<Self, Error> {
         let lev = DynamicLevenshtein {
             query: query.to_owned(),
@@ -142,16 +143,20 @@ impl DynamicLevenshtein {
 impl Automaton for Levenshtein {
     type State = Option<usize>;
 
+    #[inline]
     fn start(&self) -> Option<usize> { Some(0) }
 
+    #[inline]
     fn is_match(&self, state: &Option<usize>) -> bool {
         state.map(|state| self.dfa.states[state].is_match).unwrap_or(false)
     }
 
+    #[inline]
     fn can_match(&self, state: &Option<usize>) -> bool {
         state.is_some()
     }
 
+    #[inline]
     fn accept(&self, state: &Option<usize>, byte: u8) -> Option<usize> {
         state.and_then(|state| self.dfa.states[state].next[byte as usize])
     }

--- a/fst-regex/src/error.rs
+++ b/fst-regex/src/error.rs
@@ -40,6 +40,7 @@ pub enum Error {
 }
 
 impl From<regex_syntax::Error> for Error {
+    #[inline]
     fn from(err: regex_syntax::Error) -> Error {
         Error::Syntax(err)
     }

--- a/fst-regex/src/lib.rs
+++ b/fst-regex/src/lib.rs
@@ -119,6 +119,7 @@ impl Regex {
     ///
     /// A `Regex` value satisfies the `Automaton` trait, which means it can be
     /// used with the `search` method of any finite state transducer.
+    #[inline]
     pub fn new(re: &str) -> Result<Regex, Error> {
         Regex::with_size_limit(10 * (1 << 20), re)
     }
@@ -134,16 +135,20 @@ impl Regex {
 impl Automaton for Regex {
     type State = Option<usize>;
 
+    #[inline]
     fn start(&self) -> Option<usize> { Some(0) }
 
+    #[inline]
     fn is_match(&self, state: &Option<usize>) -> bool {
         state.map(|state| self.dfa.is_match(state)).unwrap_or(false)
     }
 
+    #[inline]
     fn can_match(&self, state: &Option<usize>) -> bool {
         state.is_some()
     }
 
+    #[inline]
     fn accept(&self, state: &Option<usize>, byte: u8) -> Option<usize> {
         state.and_then(|state| self.dfa.accept(state, byte))
     }

--- a/src/automaton/mod.rs
+++ b/src/automaton/mod.rs
@@ -155,6 +155,7 @@ pub struct Subsequence<'a> {
 impl<'a> Subsequence<'a> {
     /// Constructs automaton that matches input containing the
     /// specified subsequence.
+    #[inline]
     pub fn new(subsequence: &'a str) -> Subsequence<'a> {
         Subsequence { subseq: subsequence.as_bytes() }
     }
@@ -163,18 +164,23 @@ impl<'a> Subsequence<'a> {
 impl<'a> Automaton for Subsequence<'a> {
     type State = usize;
 
+    #[inline]
     fn start(&self) -> usize { 0 }
 
+    #[inline]
     fn is_match(&self, &state: &usize) -> bool {
         state == self.subseq.len()
     }
 
+    #[inline]
     fn can_match(&self, _: &usize) -> bool { true }
 
+    #[inline]
     fn will_always_match(&self, &state: &usize) -> bool {
         state == self.subseq.len()
     }
 
+    #[inline]
     fn accept(&self, &state: &usize, byte: u8) -> usize {
         if state == self.subseq.len() { return state; }
         state + (byte == self.subseq[state]) as usize
@@ -190,11 +196,11 @@ pub struct AlwaysMatch;
 impl Automaton for AlwaysMatch {
     type State = ();
 
-    fn start(&self) -> () { () }
-    fn is_match(&self, _: &()) -> bool { true }
-    fn can_match(&self, _: &()) -> bool { true }
-    fn will_always_match(&self, _: &()) -> bool { true }
-    fn accept(&self, _: &(), _: u8) -> () { () }
+    #[inline] fn start(&self) -> () { () }
+    #[inline] fn is_match(&self, _: &()) -> bool { true }
+    #[inline] fn can_match(&self, _: &()) -> bool { true }
+    #[inline] fn will_always_match(&self, _: &()) -> bool { true }
+    #[inline] fn accept(&self, _: &(), _: u8) -> () { () }
 }
 
 /// An automaton that matches a string that begins with something that the
@@ -211,6 +217,7 @@ enum StartsWithStateInternal<A: Automaton> {
 
 impl<A: Automaton> Automaton for StartsWith<A> {
     type State = StartsWithState<A>;
+
     fn start(&self) -> StartsWithState<A> {
         StartsWithState({
             let inner = self.0.start();

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,12 +18,14 @@ pub enum Error {
 }
 
 impl From<io::Error> for Error {
+    #[inline]
     fn from(err: io::Error) -> Error {
         Error::Io(err)
     }
 }
 
 impl From<raw::Error> for Error {
+    #[inline]
     fn from(err: raw::Error) -> Error {
         Error::Fst(err)
     }

--- a/src/map.rs
+++ b/src/map.rs
@@ -167,6 +167,7 @@ impl Map {
     ///     (b"c".to_vec(), 3),
     /// ]);
     /// ```
+    #[inline]
     pub fn stream(&self) -> Stream {
         Stream(self.0.stream())
     }
@@ -189,6 +190,7 @@ impl Map {
     /// }
     /// assert_eq!(keys, vec![b"a", b"b", b"c"]);
     /// ```
+    #[inline]
     pub fn keys(&self) -> Keys {
         Keys(self.0.stream())
     }
@@ -212,6 +214,7 @@ impl Map {
     /// }
     /// assert_eq!(values, vec![1, 2, 3]);
     /// ```
+    #[inline]
     pub fn values(&self) -> Values {
         Values(self.0.stream())
     }
@@ -247,6 +250,7 @@ impl Map {
     ///     (b"d".to_vec(), 4),
     /// ]);
     /// ```
+    #[inline]
     pub fn range(&self) -> StreamBuilder {
         StreamBuilder(self.0.range())
     }
@@ -299,11 +303,13 @@ impl Map {
     }
 
     /// Returns the number of elements in this map.
+    #[inline]
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
     /// Returns true if and only if this map is empty.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
@@ -351,17 +357,20 @@ impl Map {
     ///     (b"z".to_vec(), vec![IndexedValue { index: 1, value: 12 }]),
     /// ]);
     /// ```
+    #[inline]
     pub fn op(&self) -> OpBuilder {
         OpBuilder::new().add(self)
     }
 
     /// Returns a reference to the underlying raw finite state transducer.
+    #[inline]
     pub fn as_fst(&self) -> &raw::Fst {
         &self.0
     }
 }
 
 impl Default for Map {
+    #[inline]
     fn default() -> Map {
         Map::from_iter(iter::empty::<(&[u8], u64)>()).unwrap()
     }
@@ -385,6 +394,7 @@ impl fmt::Debug for Map {
 
 // Construct a map from an Fst object.
 impl From<raw::Fst> for Map {
+    #[inline]
     fn from(fst: raw::Fst) -> Map {
         Map(fst)
     }
@@ -392,6 +402,7 @@ impl From<raw::Fst> for Map {
 
 /// Returns the underlying finite state transducer.
 impl AsRef<raw::Fst> for Map {
+    #[inline]
     fn as_ref(&self) -> &raw::Fst {
         &self.0
     }
@@ -401,6 +412,7 @@ impl<'m, 'a> IntoStreamer<'a> for &'m Map {
     type Item = (&'a [u8], u64);
     type Into = Stream<'m>;
 
+    #[inline]
     fn into_stream(self) -> Self::Into {
         Stream(self.0.stream())
     }
@@ -503,6 +515,7 @@ pub struct MapBuilder<W>(raw::Builder<W>);
 
 impl MapBuilder<Vec<u8>> {
     /// Create a builder that builds a map in memory.
+    #[inline]
     pub fn memory() -> Self {
         MapBuilder(raw::Builder::memory())
     }
@@ -646,6 +659,7 @@ pub struct Keys<'m>(raw::Stream<'m>);
 impl<'a, 'm> Streamer<'a> for Keys<'m> {
     type Item = &'a [u8];
 
+    #[inline]
     fn next(&'a mut self) -> Option<Self::Item> {
         self.0.next().map(|(key, _)| key)
     }
@@ -660,6 +674,7 @@ pub struct Values<'m>(raw::Stream<'m>);
 impl<'a, 'm> Streamer<'a> for Values<'m> {
     type Item = u64;
 
+    #[inline]
     fn next(&'a mut self) -> Option<Self::Item> {
         self.0.next().map(|(_, out)| out.value())
     }
@@ -731,6 +746,7 @@ pub struct OpBuilder<'m>(raw::OpBuilder<'m>);
 
 impl<'m> OpBuilder<'m> {
     /// Create a new set operation builder.
+    #[inline]
     pub fn new() -> Self {
         OpBuilder(raw::OpBuilder::new())
     }
@@ -799,6 +815,7 @@ impl<'m> OpBuilder<'m> {
     ///     (b"z".to_vec(), vec![IndexedValue { index: 1, value: 13 }]),
     /// ]);
     /// ```
+    #[inline]
     pub fn union(self) -> Union<'m> {
         Union(self.0.union())
     }
@@ -839,6 +856,7 @@ impl<'m> OpBuilder<'m> {
     ///     ]),
     /// ]);
     /// ```
+    #[inline]
     pub fn intersection(self) -> Intersection<'m> {
         Intersection(self.0.intersection())
     }
@@ -879,6 +897,7 @@ impl<'m> OpBuilder<'m> {
     ///     (b"c".to_vec(), vec![IndexedValue { index: 0, value: 3 }]),
     /// ]);
     /// ```
+    #[inline]
     pub fn difference(self) -> Difference<'m> {
         Difference(self.0.difference())
     }
@@ -926,6 +945,7 @@ impl<'m> OpBuilder<'m> {
     ///     (b"z".to_vec(), vec![IndexedValue { index: 1, value: 13 }]),
     /// ]);
     /// ```
+    #[inline]
     pub fn symmetric_difference(self) -> SymmetricDifference<'m> {
         SymmetricDifference(self.0.symmetric_difference())
     }
@@ -959,6 +979,7 @@ pub struct Union<'m>(raw::Union<'m>);
 impl<'a, 'm> Streamer<'a> for Union<'m> {
     type Item = (&'a [u8], &'a [IndexedValue]);
 
+    #[inline]
     fn next(&'a mut self) -> Option<Self::Item> {
         self.0.next()
     }
@@ -973,6 +994,7 @@ pub struct Intersection<'m>(raw::Intersection<'m>);
 impl<'a, 'm> Streamer<'a> for Intersection<'m> {
     type Item = (&'a [u8], &'a [IndexedValue]);
 
+    #[inline]
     fn next(&'a mut self) -> Option<Self::Item> {
         self.0.next()
     }
@@ -991,6 +1013,7 @@ pub struct Difference<'m>(raw::Difference<'m>);
 impl<'a, 'm> Streamer<'a> for Difference<'m> {
     type Item = (&'a [u8], &'a [IndexedValue]);
 
+    #[inline]
     fn next(&'a mut self) -> Option<Self::Item> {
         self.0.next()
     }
@@ -1005,6 +1028,7 @@ pub struct SymmetricDifference<'m>(raw::SymmetricDifference<'m>);
 impl<'a, 'm> Streamer<'a> for SymmetricDifference<'m> {
     type Item = (&'a [u8], &'a [IndexedValue]);
 
+    #[inline]
     fn next(&'a mut self) -> Option<Self::Item> {
         self.0.next()
     }

--- a/src/raw/build.rs
+++ b/src/raw/build.rs
@@ -99,6 +99,7 @@ struct LastTransition {
 
 impl Builder<Vec<u8>> {
     /// Create a builder that builds an fst in memory.
+    #[inline]
     pub fn memory() -> Self {
         Builder::new(Vec::with_capacity(10 * (1 << 10))).unwrap()
     }

--- a/src/raw/error.rs
+++ b/src/raw/error.rs
@@ -114,6 +114,7 @@ impl error::Error for Error {
 }
 
 impl From<FromUtf8Error> for Error {
+    #[inline]
     fn from(err: FromUtf8Error) -> Self {
         Error::FromUtf8(err)
     }

--- a/src/raw/mmap.rs
+++ b/src/raw/mmap.rs
@@ -27,6 +27,7 @@ impl MmapReadOnly {
     /// backed by a memory mapped file won't be mutably aliased. It is up to
     /// the caller to enforce that the memory map is not modified while it is
     /// opened.
+    #[inline]
     pub unsafe fn open(file: &fs::File) -> io::Result<MmapReadOnly> {
         let mmap = Mmap::map(file)?;
         let len = mmap.len();
@@ -52,7 +53,8 @@ impl MmapReadOnly {
     /// Returns the size in byte of the memory map.
     ///
     /// If it is a range, the size is the size of the range.
-    pub fn len(&self,) -> usize {
+    #[inline]
+    pub fn len(&self) -> usize {
         self.len
     }
 
@@ -60,6 +62,7 @@ impl MmapReadOnly {
     ///
     /// If the new range is outside the bounds of `self`, then this method
     /// panics.
+    #[inline]
     pub fn range(&self, offset: usize, len: usize) -> MmapReadOnly {
         assert!(offset + len <= self.len);
         MmapReadOnly {
@@ -70,12 +73,14 @@ impl MmapReadOnly {
     }
 
     /// Read the memory map as a `&[u8]`.
+    #[inline]
     pub fn as_slice(&self) -> &[u8] {
         &self.map[self.offset..self.offset + self.len]
     }
 }
 
 impl Clone for MmapReadOnly {
+    #[inline]
     fn clone(&self) -> MmapReadOnly {
         MmapReadOnly{
             map: self.map.clone(),

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -306,6 +306,7 @@ impl Fst {
     /// A `MmapReadOnly` lets one control which region of the file is used for
     /// the transducer.
     #[cfg(feature = "mmap")]
+    #[inline]
     pub fn from_mmap(mmap: MmapReadOnly) -> Result<Self> {
         Fst::new(FstData::Mmap(mmap))
     }
@@ -318,6 +319,7 @@ impl Fst {
     /// transducer builder (`Builder` qualifies). If the format is invalid or
     /// if there is a mismatch between the API version of this library and the
     /// fst, then an error is returned.
+    #[inline]
     pub fn from_bytes(bytes: Vec<u8>) -> Result<Self> {
         Fst::new(FstData::Cow(Cow::Owned(bytes)))
     }
@@ -326,6 +328,7 @@ impl Fst {
     ///
     /// This accepts a static byte slice, which may be useful if the Fst
     /// is embedded into source code.
+    #[inline]
     pub fn from_static_slice(bytes: &'static [u8]) -> Result<Self> {
         Fst::new(FstData::Cow(Cow::Borrowed(bytes)))
     }
@@ -335,6 +338,7 @@ impl Fst {
     ///
     /// This permits creating multiple transducers from a single region of
     /// owned memory.
+    #[inline]
     pub fn from_shared_bytes(
         bytes: Arc<Vec<u8>>,
         offset: usize,
@@ -439,6 +443,7 @@ impl Fst {
 
     /// Return a lexicographically ordered stream of all key-value pairs in
     /// this fst.
+    #[inline]
     pub fn stream(&self) -> Stream {
         StreamBuilder::new(self, AlwaysMatch).into_stream()
     }
@@ -447,6 +452,7 @@ impl Fst {
     ///
     /// A range query returns a subset of key-value pairs in this fst in a
     /// range given in lexicographic order.
+    #[inline]
     pub fn range(&self) -> StreamBuilder {
         StreamBuilder::new(self, AlwaysMatch)
     }
@@ -457,16 +463,19 @@ impl Fst {
     }
 
     /// Returns the number of keys in this fst.
+    #[inline]
     pub fn len(&self) -> usize {
         self.len
     }
 
     /// Returns true if and only if this fst has no keys.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.len == 0
     }
 
     /// Returns the number of bytes used by this fst.
+    #[inline]
     pub fn size(&self) -> usize {
         self.data.len()
     }
@@ -477,6 +486,7 @@ impl Fst {
     /// and perform set operations like union, intersection, difference and
     /// symmetric difference on the keys of the fst. These set operations also
     /// allow one to specify how conflicting values are merged in the stream.
+    #[inline]
     pub fn op(&self) -> OpBuilder {
         OpBuilder::new().add(self)
     }
@@ -531,6 +541,7 @@ impl Fst {
     ///
     /// This crate reserves the range 0-255 (inclusive) but currently leaves
     /// the meaning of 0-255 unspecified.
+    #[inline]
     pub fn fst_type(&self) -> FstType {
         self.ty
     }
@@ -544,11 +555,13 @@ impl Fst {
     /// Returns the node at the given address.
     ///
     /// Node addresses can be obtained by reading transitions on `Node` values.
+    #[inline]
     pub fn node(&self, addr: CompiledAddr) -> Node {
         node_new(self.version, addr, &self.data)
     }
 
     /// Returns a copy of the binary contents of this FST.
+    #[inline]
     pub fn to_vec(&self) -> Vec<u8> {
         self.data.to_vec()
     }
@@ -567,6 +580,7 @@ impl<'a, 'f> IntoStreamer<'a> for &'f Fst {
     type Item = (&'a [u8], Output);
     type Into = Stream<'f>;
 
+    #[inline]
     fn into_stream(self) -> Self::Into {
         StreamBuilder::new(self, AlwaysMatch).into_stream()
     }
@@ -1006,6 +1020,7 @@ pub struct Transition {
 }
 
 impl Default for Transition {
+    #[inline]
     fn default() -> Self {
         Transition {
             inp: 0,

--- a/src/raw/node.rs
+++ b/src/raw/node.rs
@@ -123,6 +123,7 @@ pub fn node_new(version: u64, addr: CompiledAddr, data: &[u8]) -> Node {
 impl<'f> Node<'f> {
     /// Returns an iterator over all transitions in this node in lexicographic
     /// order.
+    #[inline]
     pub fn transitions<'n>(&'n self) -> Transitions<'f, 'n> {
         Transitions { node: self, range: 0..self.len() }
     }
@@ -771,6 +772,7 @@ pub struct Transitions<'f: 'n, 'n> {
 impl<'f, 'n> Iterator for Transitions<'f, 'n> {
     type Item = Transition;
 
+    #[inline]
     fn next(&mut self) -> Option<Transition> {
         self.range.next().map(|i| self.node.transition(i))
     }

--- a/src/raw/ops.rs
+++ b/src/raw/ops.rs
@@ -46,6 +46,7 @@ pub struct OpBuilder<'f> {
 
 impl<'f> OpBuilder<'f> {
     /// Create a new set operation builder.
+    #[inline]
     pub fn new() -> Self {
         OpBuilder { streams: vec![] }
     }
@@ -83,6 +84,7 @@ impl<'f> OpBuilder<'f> {
     /// with that key in that stream. The index uniquely identifies each
     /// stream, which is an integer that is auto-incremented when a stream
     /// is added to this operation (starting at `0`).
+    #[inline]
     pub fn union(self) -> Union<'f> {
         Union {
             heap: StreamHeap::new(self.streams),
@@ -100,6 +102,7 @@ impl<'f> OpBuilder<'f> {
     /// with that key in that stream. The index uniquely identifies each
     /// stream, which is an integer that is auto-incremented when a stream
     /// is added to this operation (starting at `0`).
+    #[inline]
     pub fn intersection(self) -> Intersection<'f> {
         Intersection {
             heap: StreamHeap::new(self.streams),
@@ -119,6 +122,7 @@ impl<'f> OpBuilder<'f> {
     /// with that key in that stream. The index uniquely identifies each
     /// stream, which is an integer that is auto-incremented when a stream
     /// is added to this operation (starting at `0`).
+    #[inline]
     pub fn difference(mut self) -> Difference<'f> {
         let first = self.streams.swap_remove(0);
         Difference {
@@ -145,6 +149,7 @@ impl<'f> OpBuilder<'f> {
     /// with that key in that stream. The index uniquely identifies each
     /// stream, which is an integer that is auto-incremented when a stream
     /// is added to this operation (starting at `0`).
+    #[inline]
     pub fn symmetric_difference(self) -> SymmetricDifference<'f> {
         SymmetricDifference {
             heap: StreamHeap::new(self.streams),

--- a/src/set.rs
+++ b/src/set.rs
@@ -56,6 +56,7 @@ impl Set {
     /// transducer builder (`SetBuilder` qualifies). If the format is invalid
     /// or if there is a mismatch between the API version of this library
     /// and the set, then an error is returned.
+    #[inline]
     pub fn from_bytes(bytes: Vec<u8>) -> Result<Self> {
         raw::Fst::from_bytes(bytes).map(Set)
     }
@@ -119,6 +120,7 @@ impl Set {
     /// }
     /// assert_eq!(keys, vec![b"a", b"b", b"c"]);
     /// ```
+    #[inline]
     pub fn stream(&self) -> Stream {
         Stream(self.0.stream())
     }
@@ -148,6 +150,7 @@ impl Set {
     /// }
     /// assert_eq!(keys, vec![b"b", b"c", b"d"]);
     /// ```
+    #[inline]
     pub fn range(&self) -> StreamBuilder {
         StreamBuilder(self.0.range())
     }
@@ -198,11 +201,13 @@ impl Set {
     }
 
     /// Returns the number of elements in this set.
+    #[inline]
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
     /// Returns true if and only if this set is empty.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
@@ -229,6 +234,7 @@ impl Set {
     /// }
     /// assert_eq!(keys, vec![b"a", b"b", b"c", b"y", b"z"]);
     /// ```
+    #[inline]
     pub fn op(&self) -> OpBuilder {
         OpBuilder::new().add(self)
     }
@@ -309,12 +315,14 @@ impl Set {
     }
 
     /// Returns a reference to the underlying raw finite state transducer.
+    #[inline]
     pub fn as_fst(&self) -> &raw::Fst {
         &self.0
     }
 }
 
 impl Default for Set {
+    #[inline]
     fn default() -> Set {
         Set::from_iter(iter::empty::<&[u8]>()).unwrap()
     }
@@ -338,6 +346,7 @@ impl fmt::Debug for Set {
 
 /// Returns the underlying finite state transducer.
 impl AsRef<raw::Fst> for Set {
+    #[inline]
     fn as_ref(&self) -> &raw::Fst {
         &self.0
     }
@@ -347,6 +356,7 @@ impl<'s, 'a> IntoStreamer<'a> for &'s Set {
     type Item = &'a [u8];
     type Into = Stream<'s>;
 
+    #[inline]
     fn into_stream(self) -> Self::Into {
         Stream(self.0.stream())
     }
@@ -354,6 +364,7 @@ impl<'s, 'a> IntoStreamer<'a> for &'s Set {
 
 // Construct a set from an Fst object.
 impl From<raw::Fst> for Set {
+    #[inline]
     fn from(fst: raw::Fst) -> Set {
         Set(fst)
     }
@@ -450,6 +461,7 @@ pub struct SetBuilder<W>(raw::Builder<W>);
 
 impl SetBuilder<Vec<u8>> {
     /// Create a builder that builds a set in memory.
+    #[inline]
     pub fn memory() -> Self {
         SetBuilder(raw::Builder::memory())
     }
@@ -624,6 +636,7 @@ pub struct OpBuilder<'s>(raw::OpBuilder<'s>);
 
 impl<'s> OpBuilder<'s> {
     /// Create a new set operation builder.
+    #[inline]
     pub fn new() -> Self {
         OpBuilder(raw::OpBuilder::new())
     }
@@ -670,6 +683,7 @@ impl<'s> OpBuilder<'s> {
     /// }
     /// assert_eq!(keys, vec![b"a", b"b", b"c", b"y", b"z"]);
     /// ```
+    #[inline]
     pub fn union(self) -> Union<'s> {
         Union(self.0.union())
     }
@@ -692,6 +706,7 @@ impl<'s> OpBuilder<'s> {
     /// }
     /// assert_eq!(keys, vec![b"a"]);
     /// ```
+    #[inline]
     pub fn intersection(self) -> Intersection<'s> {
         Intersection(self.0.intersection())
     }
@@ -716,6 +731,7 @@ impl<'s> OpBuilder<'s> {
     /// }
     /// assert_eq!(keys, vec![b"b", b"c"]);
     /// ```
+    #[inline]
     pub fn difference(self) -> Difference<'s> {
         Difference(self.0.difference())
     }
@@ -745,6 +761,7 @@ impl<'s> OpBuilder<'s> {
     /// }
     /// assert_eq!(keys, vec![b"b", b"c", b"y", b"z"]);
     /// ```
+    #[inline]
     pub fn symmetric_difference(self) -> SymmetricDifference<'s> {
         SymmetricDifference(self.0.symmetric_difference())
     }
@@ -778,6 +795,7 @@ pub struct Union<'s>(raw::Union<'s>);
 impl<'a, 's> Streamer<'a> for Union<'s> {
     type Item = &'a [u8];
 
+    #[inline]
     fn next(&'a mut self) -> Option<Self::Item> {
         self.0.next().map(|(key, _)| key)
     }
@@ -791,6 +809,7 @@ pub struct Intersection<'s>(raw::Intersection<'s>);
 impl<'a, 's> Streamer<'a> for Intersection<'s> {
     type Item = &'a [u8];
 
+    #[inline]
     fn next(&'a mut self) -> Option<Self::Item> {
         self.0.next().map(|(key, _)| key)
     }
@@ -808,6 +827,7 @@ pub struct Difference<'s>(raw::Difference<'s>);
 impl<'a, 's> Streamer<'a> for Difference<'s> {
     type Item = &'a [u8];
 
+    #[inline]
     fn next(&'a mut self) -> Option<Self::Item> {
         self.0.next().map(|(key, _)| key)
     }
@@ -822,6 +842,7 @@ pub struct SymmetricDifference<'s>(raw::SymmetricDifference<'s>);
 impl<'a, 's> Streamer<'a> for SymmetricDifference<'s> {
     type Item = &'a [u8];
 
+    #[inline]
     fn next(&'a mut self) -> Option<Self::Item> {
         self.0.next().map(|(key, _)| key)
     }


### PR DESCRIPTION
Without link-time optimization, Rust cannot inline non-generic functions across crate boundary.

This patch adds `#[inline]` annotation to trivial public non-generic functions so that Rust can inline them on callsites.