### PR TITLE
Implement Clone and Debug on automatons

### DIFF
--- a/src/automaton/mod.rs
+++ b/src/automaton/mod.rs
@@ -147,7 +147,7 @@ impl<'a, T: Automaton> Automaton for &'a T {
 ///     Ok(())
 /// }
 /// ```
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct Subsequence<'a> {
     subseq: &'a [u8]
 }
@@ -185,6 +185,7 @@ impl<'a> Automaton for Subsequence<'a> {
 ///
 /// This is useful in a generic context as a way to express that no automaton
 /// should be used.
+#[derive(Clone, Debug)]
 pub struct AlwaysMatch;
 
 impl Automaton for AlwaysMatch {
@@ -199,6 +200,7 @@ impl Automaton for AlwaysMatch {
 
 /// An automaton that matches a string that begins with something that the
 /// wrapped automaton matches.
+#[derive(Clone, Debug)]
 pub struct StartsWith<A>(A);
 
 /// The `Automaton` state for `StartsWith<A>`.
@@ -265,6 +267,7 @@ impl<A: Automaton> Automaton for StartsWith<A> {
 }
 
 /// An automaton that matches when one of its component automata match.
+#[derive(Clone, Debug)]
 pub struct Union<A, B>(A, B);
 
 /// The `Automaton` state for `Union<A, B>`.
@@ -302,6 +305,7 @@ impl<A: Automaton, B: Automaton> Automaton for Union<A, B> {
 }
 
 /// An automaton that matches when both of its component automata match.
+#[derive(Clone, Debug)]
 pub struct Intersection<A, B>(A, B);
 
 /// The `Automaton` state for `Intersection<A, B>`.
@@ -342,6 +346,7 @@ impl<A: Automaton, B: Automaton> Automaton for Intersection<A, B> {
 }
 
 /// An automaton that matches exactly when the automaton it wraps does not.
+#[derive(Clone, Debug)]
 pub struct Complement<A>(A);
 
 /// The `Automaton` state for `Complement<A>`.


### PR DESCRIPTION
This PR propose to add Clone and Debug traits using the derive syntax on the native automatons.

These traits was already implemented [by `SubSequence`](https://github.com/BurntSushi/fst/blob/ccd50804450fe347130c704d84868cdf878d52e8/src/automaton/mod.rs#L150).

I find this useful in some of my usages.
These additions doesn't introduce breaking changes to the library.