### PR TITLE
Adding a `mmap` feature to `fst-regex`.

### DIFF
--- a/fst-regex/Cargo.toml
+++ b/fst-regex/Cargo.toml
@@ -11,7 +11,11 @@ repository = "https://github.com/BurntSushi/fst"
 keywords = ["search", "information", "retrieval", "dictionary", "map"]
 license = "Unlicense/MIT"
 
+[features]
+mmap = ["fst/mmap"]
+default = ["mmap"]
+
 [dependencies]
-fst = { path = "..", version = "0.3.1" }
+fst = { path = "..", version = "0.3.1", default-features = false }
 regex-syntax = "0.3"
 utf8-ranges = "1"


### PR DESCRIPTION
The feature is there by default and just enables the `mmap` feature
in the fst crate when unabled.

Closes #70