### PR TITLE
docs: Explicitly point out than difference has 1 IndexValue

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -873,6 +873,10 @@ impl<'m> OpBuilder<'m> {
     /// stream, which is an integer that is auto-incremented when a stream
     /// is added to this operation (starting at `0`).
     ///
+    /// While the interface is the same for all the operations combining multiple
+    /// maps, due to the nature of `difference` there's exactly one `IndexValue`
+    /// for each yielded value.
+    ///
     /// # Example
     ///
     /// ```rust

--- a/src/raw/ops.rs
+++ b/src/raw/ops.rs
@@ -122,6 +122,10 @@ impl<'f> OpBuilder<'f> {
     /// with that key in that stream. The index uniquely identifies each
     /// stream, which is an integer that is auto-incremented when a stream
     /// is added to this operation (starting at `0`).
+    ///
+    /// The interface is the same for all the operations, but due to the nature
+    /// of `difference`, each yielded key contains exactly one `IndexValue` with
+    /// `index` set to 0.
     #[inline]
     pub fn difference(mut self) -> Difference<'f> {
         let first = self.streams.swap_remove(0);


### PR DESCRIPTION
Reading the docs previously was a bit confusing ‒ while the nature of
the operation hints at exactly one IndexValue, the interface hints at
arbitrary number and the docs kind of did too and one has to wonder what
the trick is. Pointing it out explicitly should prevent the latter.