### PR TITLE
Raw fst .as_bytes()

### DIFF
--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -565,6 +565,12 @@ impl Fst {
         self.data.to_vec()
     }
 
+    /// Returns the binary contents of this FST.
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.data
+    }
+
     fn empty_final_output(&self) -> Option<Output> {
         let root = self.root();
         if root.is_final() {


### PR DESCRIPTION
Similar to .to_vec(), but without making copies.

# Motivation

* Currently, I'm keeping a map in memory and exchange it from time to time. Later on I'd like to store it to a cache (but not at the time when I'm constructing it) and currently I have to use the `to_vec` and then `write_all` ‒ which is wasteful, because it creates a copy of the whole thing in memory.
* For some metrics I'd like to know the size of the image (not .len() ‒ that one is number of keys). Calling `to_vec` for that is obviously too wasteful.

If this change is OK, would it be fine to have a release with it?

Thank you