### PR TITLE
Add `fst::Str` automaton for exact strings

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -6,7 +6,7 @@ use fst_levenshtein::Levenshtein;
 use fst_regex::Regex;
 
 use fst::{Automaton, IntoStreamer, Streamer};
-use fst::automaton::Subsequence;
+use fst::automaton::{Str, Subsequence};
 use fst::raw::{Builder, Fst, Output};
 use fst::set::{Set, OpBuilder};
 
@@ -137,6 +137,26 @@ fn union_large() {
         assert_eq!(stream2.next(), Some(key1));
     }
     assert_eq!(stream2.next(), None);
+}
+
+#[test]
+fn str() {
+    let set = get_set();
+
+    let exact = Str::new("vatican");
+    let mut stream = set.search(&exact).into_stream();
+    assert_eq!(stream.next().unwrap(), b"vatican");
+    assert_eq!(stream.next(), None);
+
+    let exact_mismatch = Str::new("abracadabra");
+    let mut stream = set.search(&exact_mismatch).into_stream();
+    assert_eq!(stream.next(), None);
+
+    let starts_with = Str::new("vati").starts_with();
+    let mut stream = set.search(&starts_with).into_stream();
+    assert_eq!(stream.next().unwrap(), b"vatican");
+    assert_eq!(stream.next().unwrap(), b"vation");
+    assert_eq!(stream.next(), None);
 }
 
 #[test]


### PR DESCRIPTION
This adds ability to match exact strings against the given set, as well as enables trie usecase by combining it with `StartsWith<_>`.

Name is subject to change, I don't have strong preferences either way, as well as would be happy with just implementing `Automaton` directly on `str` / `[u8]` (which seems to make sense).