### PR TITLE
Implement Clone on Map, Set and raw::Fst

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -54,6 +54,7 @@ use Result;
 /// Keys will always be byte strings; however, we may grow more conveniences
 /// around dealing with them (such as a serialization/deserialization step,
 /// although it isn't clear where exactly this should live).
+#[derive(Clone)]
 pub struct Map(raw::Fst);
 
 impl Map {

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -274,6 +274,7 @@ pub type CompiledAddr = usize;
 ///   (excellent for in depth overview)
 /// * [Comparison of Construction Algorithms for Minimal, Acyclic, Deterministic, Finite-State Automata from Sets of Strings](http://www.cs.mun.ca/~harold/Courses/Old/CS4750/Diary/q3p2qx4lv71m5vew.pdf)
 ///   (excellent for surface level overview)
+#[derive(Clone)]
 pub struct Fst {
     version: u64,
     data: FstData,
@@ -987,6 +988,7 @@ impl Output {
     }
 }
 
+#[derive(Clone)]
 enum FstData {
     Cow(Cow<'static, [u8]>),
     Shared {

--- a/src/set.rs
+++ b/src/set.rs
@@ -29,6 +29,7 @@ use Result;
 ///
 /// 1. Once constructed, a `Set` can never be modified.
 /// 2. Sets must be constructed with lexicographically ordered byte sequences.
+#[derive(Clone)]
 pub struct Set(raw::Fst);
 
 impl Set {


### PR DESCRIPTION
This pull request implement Clone for `Map`, `Set` and `raw::Fst` types this way it is more convenient to clone these types than before.

```rust
// before
let cloned = fst::Set::from_bytes(my_set.as_fst().to_vec()).unwrap();

// after
let cloned = my_set.clone();
```