### PR TITLE
Add a `mmap` feature to `fst-levenshtein`.

### DIFF
--- a/fst-levenshtein/Cargo.toml
+++ b/fst-levenshtein/Cargo.toml
@@ -11,6 +11,10 @@ repository = "https://github.com/BurntSushi/fst"
 keywords = ["search", "information", "retrieval", "dictionary", "map"]
 license = "Unlicense/MIT"
 
+[features]
+mmap = ["fst/mmap"]
+default = ["mmap"]
+
 [dependencies]
-fst = { path = "..", version = "0.3.1" }
+fst = { path = "..", version = "0.3.1", default-features = false }
 utf8-ranges = "1"


### PR DESCRIPTION
Similarly to #70, `fst-levenshtein` inherits the `mmap` feature, which means it can't be used in WebAssembly without forking and modifying locally.

Hopefully you would consider this addition as well.

Thanks!