### PR TITLE
Introduce a convenient method to create an fst from a builder

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -541,6 +541,11 @@ impl MapBuilder<Vec<u8>> {
     pub fn memory() -> Self {
         MapBuilder(raw::Builder::memory())
     }
+
+    /// Finishes the construction of the map and returning it.
+    pub fn into_map(self) -> Map {
+        self.into_inner().and_then(Map::from_bytes).unwrap()
+    }
 }
 
 impl<W: io::Write> MapBuilder<W> {

--- a/src/set.rs
+++ b/src/set.rs
@@ -487,6 +487,11 @@ impl SetBuilder<Vec<u8>> {
     pub fn memory() -> Self {
         SetBuilder(raw::Builder::memory())
     }
+
+    /// Finishes the construction of the set and returning it.
+    pub fn into_set(self) -> Set {
+        self.into_inner().and_then(Set::from_bytes).unwrap()
+    }
 }
 
 impl<W: io::Write> SetBuilder<W> {


### PR DESCRIPTION
This PR propose to add a convenient method on the `Set` and `Map` builders to directly create a `Set` or `Map` from the builder itself.

The advantage here is to reduce the number of unwraps necessary to create a `Set`/`Map` from a `Set`/`MapBuilder` based on a _known valid_ `Vec<u8>`.

```rust
let mut build = MapBuilder::memory();
build.insert("bruce", 1).unwrap();
build.insert("clarence", 2).unwrap();
build.insert("stevie", 3).unwrap();

// current way of constructing a known valid map from a builder
let bytes = build.into_inner().unwrap();
let map = Map::from_bytes(bytes).unwrap();
// could also be written as
let map = build.into_inner().and_then(Map::from_bytes).unwrap();

// new way (no more useless unwraps)
let map = build.into_map();
```