### PR TITLE
Fix Rust 1.24 support by locking down some versions

### DIFF
--- a/fst-bin/Cargo.toml
+++ b/fst-bin/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 [dependencies]
 bit-set = "0.4"
 chan = "0.1"
-csv = "1.0.0-beta.3"
+csv = "~1.0.0-beta.3"
 docopt = "0.8"
 fst = { path = "..", version = "0.3" }
 fst-regex = { path = "../fst-regex", version = "0.2" }
@@ -29,8 +29,14 @@ fst-levenshtein = { path = "../fst-levenshtein", version = "0.2" }
 lines = "0.0"
 num_cpus = "1.5"
 serde = "1"
-serde_derive = "1"
+serde_derive = ">= 1, <1.0.83"
 tempdir = "0.3"
+
+# Lockdowns for Rust 1.24 support
+cfg-if = "= 0.1.6"
+csv-core = "= 0.1.4"
+lazy_static = "~1.2"
+memchr = "= 2.1.2"
 
 [profile.release]
 debug = true


### PR DESCRIPTION
Based off the versions that worked in the last good 1.24 build at https://travis-ci.org/BurntSushi/fst/jobs/468402724