### PR TITLE
Introduce a method to retrieve the inner data of an Fst

### DIFF
--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -639,6 +639,14 @@ impl<D: AsRef<[u8]>> Fst<D> {
     }
 }
 
+impl<D> Fst<D> {
+    /// Returns the underlying data which constitutes the FST itself.
+    #[inline]
+    pub fn into_inner(self) -> D {
+        self.data
+    }
+}
+
 impl<'a, 'f, D: AsRef<[u8]>> IntoStreamer<'a> for &'f Fst<D> {
     type Item = (&'a [u8], Output);
     type Into = Stream<'f>;


### PR DESCRIPTION
I think there is a missing method on the Fst to retrieve the underlying Data type.

I need this method to transform a Set based on a `&[u8]` into a Set based on a `Cow`, owned and borrowed on demand.