### PR TITLE
automaton: add new accept_eof method

### DIFF
--- a/src/automaton/mod.rs
+++ b/src/automaton/mod.rs
@@ -68,6 +68,11 @@ pub trait Automaton {
     /// Return the next state given `state` and an input.
     fn accept(&self, state: &Self::State, byte: u8) -> Self::State;
 
+    /// If applicable, return the next state when the end of a key is seen.
+    fn accept_eof(&self, _: &Self::State) -> Option<Self::State> {
+        None
+    }
+
     /// Returns an automaton that matches the strings that start with something
     /// this automaton matches.
     fn starts_with(self) -> StartsWith<Self>
@@ -126,6 +131,10 @@ impl<'a, T: Automaton> Automaton for &'a T {
 
     fn accept(&self, state: &T::State, byte: u8) -> T::State {
         (*self).accept(state, byte)
+    }
+
+    fn accept_eof(&self, state: &Self::State) -> Option<Self::State> {
+        (*self).accept_eof(state)
     }
 }
 

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1201,9 +1201,14 @@ impl<'f, A: Automaton> StreamWithState<'f, A> {
             let out = state.out.cat(trans.out);
             let next_state = self.aut.accept(&state.aut_state, trans.inp);
             let t = map(&next_state);
-            let is_match = self.aut.is_match(&next_state);
+            let mut is_match = self.aut.is_match(&next_state);
             let next_node = self.fst.node(trans.addr);
             self.inp.push(trans.inp);
+            if next_node.is_final() {
+                if let Some(eof_state) = self.aut.accept_eof(&next_state) {
+                    is_match = self.aut.is_match(&eof_state);
+                }
+            }
             self.stack.push(StreamState { trans: state.trans + 1, ..state });
             self.stack.push(StreamState {
                 node: next_node,


### PR DESCRIPTION
This is to support automata that delay matches by one byte. (Which is
what regex-automata will do in its 0.2 release, in order to support
look-around assertions such as ^, $ and \b.)

This requires a small tweak to the search code to call this new method
once it sees a final node.

This is *not* a breaking change. Existing implementations continue to
work since the default implementation of `accept_eof` (returning None)
is always correct for automata that do not delay matches.