### PR TITLE
Introduce the Set and Map into_fst method

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -51,6 +51,7 @@ use crate::Result;
 /// Keys will always be byte strings; however, we may grow more conveniences
 /// around dealing with them (such as a serialization/deserialization step,
 /// although it isn't clear where exactly this should live).
+#[derive(Clone)]
 pub struct Map<D>(raw::Fst<D>);
 
 impl Map<Vec<u8>> {

--- a/src/map.rs
+++ b/src/map.rs
@@ -425,6 +425,12 @@ fn example() -> Result<(), Box<dyn std::error::Error>> {
     pub fn as_fst(&self) -> &raw::Fst<D> {
         &self.0
     }
+
+    /// Returns the underlying raw finite state transducer.
+    #[inline]
+    pub fn into_fst(self) -> raw::Fst<D> {
+        self.0
+    }
 }
 
 impl Default for Map<Vec<u8>> {

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -267,12 +267,13 @@ pub type CompiledAddr = usize;
 ///   (excellent for in depth overview)
 /// * [Comparison of Construction Algorithms for Minimal, Acyclic, Deterministic, Finite-State Automata from Sets of Strings](http://www.cs.mun.ca/~harold/Courses/Old/CS4750/Diary/q3p2qx4lv71m5vew.pdf)
 ///   (excellent for surface level overview)
+#[derive(Clone)]
 pub struct Fst<D> {
     meta: Meta,
     data: D,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct Meta {
     version: u64,
     root_addr: CompiledAddr,

--- a/src/set.rs
+++ b/src/set.rs
@@ -26,6 +26,7 @@ use crate::Result;
 ///
 /// 1. Once constructed, a `Set` can never be modified.
 /// 2. Sets must be constructed with lexicographically ordered byte sequences.
+#[derive(Clone)]
 pub struct Set<D>(raw::Fst<D>);
 
 impl Set<Vec<u8>> {

--- a/src/set.rs
+++ b/src/set.rs
@@ -373,6 +373,12 @@ fn example() -> Result<(), Box<dyn std::error::Error>> {
     pub fn as_fst(&self) -> &raw::Fst<D> {
         &self.0
     }
+
+    /// Returns the underlying raw finite state transducer.
+    #[inline]
+    pub fn into_fst(self) -> raw::Fst<D> {
+        self.0
+    }
 }
 
 impl Default for Set<Vec<u8>> {


### PR DESCRIPTION
I would like to introduce the new `into_fst` method to the `Set` and `Map` types.

This method consumes the wrapper types and extracted the underlying raw fst, this enables many possiblities and fixes an issue I found with #102.

  1. We can change the way we want to read an fst by extracting the underlying fst of a wrapper like a Set and construct a Map from it for example (I need this in one of my libraries, this is not just a fun feature).

  2. This also fixes the issue of #102 which introduced an `into_inner` method to extract the data of a raw fst. Because the only way to get the underlying fst of a Set or a Map  was by reference using the `as_fst` method it wasn't possible to reuse the extracted `Data` and map it into another type. The original goal of #102 was to transform the data of a Set from a `Vec<u8>` to a `Cow<[u8]>` and wasn't possible because `raw::Fst` do not implement `Clone`.