### PR TITLE
Introduce a map_data method

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -432,6 +432,34 @@ fn example() -> Result<(), Box<dyn std::error::Error>> {
     pub fn into_fst(self) -> raw::Fst<D> {
         self.0
     }
+
+    /// Maps the underlying data of the fst Map to another data type.
+    ///
+    /// # Example
+    ///
+    /// This example shows that you can map an fst Map based on a `Vec<u8>`
+    /// into an fst Map based on a `Cow<[u8]>`, it can also work with a
+    /// reference counted type (e.g. `Arc`, `Rc`).
+    ///
+    /// ```
+    /// use std::borrow::Cow;
+    ///
+    /// use fst::Map;
+    ///
+    /// let map: Map<Vec<u8>> = Map::from_iter(
+    ///     [("hello", 12), ("world", 42)].iter().cloned(),
+    /// ).unwrap();
+    ///
+    /// let map_on_cow: Map<Cow<[u8]>> = map.map_data(Cow::Owned).unwrap();
+    /// ```
+    #[inline]
+    pub fn map_data<F, T>(self, f: F) -> Result<Map<T>>
+    where
+        F: FnMut(D) -> T,
+        T: AsRef<[u8]>,
+    {
+        self.into_fst().map_data(f).map(Map::from)
+    }
 }
 
 impl Default for Map<Vec<u8>> {

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -646,6 +646,16 @@ impl<D> Fst<D> {
     pub fn into_inner(self) -> D {
         self.data
     }
+
+    /// Maps the underlying data of the fst to another data type.
+    #[inline]
+    pub fn map_data<F, T>(self, mut f: F) -> Result<Fst<T>>
+    where
+        F: FnMut(D) -> T,
+        T: AsRef<[u8]>,
+    {
+        Fst::new(f(self.into_inner()))
+    }
 }
 
 impl<'a, 'f, D: AsRef<[u8]>> IntoStreamer<'a> for &'f Fst<D> {

--- a/src/set.rs
+++ b/src/set.rs
@@ -380,6 +380,34 @@ fn example() -> Result<(), Box<dyn std::error::Error>> {
     pub fn into_fst(self) -> raw::Fst<D> {
         self.0
     }
+
+    /// Maps the underlying data of the fst Set to another data type.
+    ///
+    /// # Example
+    ///
+    /// This example shows that you can map an fst Set based on a `Vec<u8>`
+    /// into an fst Set based on a `Cow<[u8]>`, it can also work with a
+    /// reference counted type (e.g. `Arc`, `Rc`).
+    ///
+    /// ```
+    /// use std::borrow::Cow;
+    ///
+    /// use fst::Set;
+    ///
+    /// let set: Set<Vec<u8>> = Set::from_iter(
+    ///     &["hello", "world"],
+    /// ).unwrap();
+    ///
+    /// let set_on_cow: Set<Cow<[u8]>> = set.map_data(Cow::Owned).unwrap();
+    /// ```
+    #[inline]
+    pub fn map_data<F, T>(self, f: F) -> Result<Set<T>>
+    where
+        F: FnMut(D) -> T,
+        T: AsRef<[u8]>,
+    {
+        self.into_fst().map_data(f).map(Set::from)
+    }
 }
 
 impl Default for Set<Vec<u8>> {


### PR DESCRIPTION
This method is implemented on the `fst::Map/Set` and `raw::Fst` types, it allows to change the underlying data type without having to deconstruct the type by hand. This can be especially usefull when an fst `Map` or `Set` is based on another type than a `Vec` and you need a default value for that type, you can call default and map it to the right data type you need (e.g. `Arc`, `Rc`, `Cow`) on a single line.

```rust
 use std::borrow::Cow;
 use std::sync::Arc;
 use fst::Map;

// Can be used with Cows
let iter = [("hello", 12), ("world", 42)].iter().cloned();
let map: Map<Vec<u8>> = Map::from_iter(iter)?;
let map_on_cow: Map<Cow<[u8]>> = map.map_data(Cow::Owned)?;

// Or even be used with Arcs
let map: Map<Vec<u8>> = Map::default();
let map_on_arc: Map<Arc<[u8]>> = map.map_data(Arc::from)?;
 ```

I have introduced an `FstExt` trait to be able to do this [in the MeiliSearch codebase](https://github.com/meilisearch/MeiliSearch/pull/706/commits/01033bc64b69113b6e9dff3d2a0ab29c8f483b84#), but I would be glad if the fst library provided it out-of-the-box.