### PR TITLE
Update mod.rs. Correction in output sub function comment.

### DIFF
--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1314,7 +1314,7 @@ impl Output {
 
     /// Returns the subtraction of `o` from this output.
     ///
-    /// This function panics if `self > o`.
+    /// This function panics if `self < o`.
     #[inline]
     pub fn sub(self, o: Output) -> Output {
         Output(


### PR DESCRIPTION
Correction in output sub function comment.

Currently reads:

/// This function panics if `self > o`.

However from looking at the code, self should always be greater than or equal to o.

So the correct direction should be:

/// This function panics if `self < o`.