### PR TITLE
Bump fst-regex and fst-levenshtein versions

### DIFF
--- a/fst-levenshtein/Cargo.toml
+++ b/fst-levenshtein/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fst-levenshtein"
-version = "0.3.0"  #:version
+version = "0.4.0"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = """
 DEPRECATED. Use 'fst' crate with 'levenshtein' feature instead.

--- a/fst-levenshtein/Cargo.toml
+++ b/fst-levenshtein/Cargo.toml
@@ -13,5 +13,5 @@ license = "Unlicense/MIT"
 edition = "2018"
 
 [dependencies]
-fst = "0.3.1"
+fst = "0.4.7"
 utf8-ranges = "1"

--- a/fst-regex/Cargo.toml
+++ b/fst-regex/Cargo.toml
@@ -13,6 +13,6 @@ license = "Unlicense/MIT"
 edition = "2018"
 
 [dependencies]
-fst = { version = "0.3.1", default-features = false }
+fst = { version = "0.4.7", default-features = false }
 regex-syntax = "0.3"
 utf8-ranges = "1"

--- a/fst-regex/Cargo.toml
+++ b/fst-regex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fst-regex"
-version = "0.3.0"  #:version
+version = "0.4.0"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = """
 DEPRECATED. Use 'regex-automata' crate with 'transducer' feature instead.


### PR DESCRIPTION
This PR updates the `fst` dependencies of the `fst-regex` and `fst-levenshtein` crates. It also bumps the versions of both crates to 0.4.0 as this is a breaking change.