### PR TITLE
[fst-bin] Add a commandline option '--delimiter' to `map`.

### DIFF
--- a/fst-bin/src/app.rs
+++ b/fst-bin/src/app.rs
@@ -288,7 +288,10 @@ pub fn app() -> clap::App<'static, 'static> {
         ))
         .arg(flag("keep-tmp-dir").help(
             "Does not delete the temporary directory. Useful for debugging.",
-        ));
+        ))
+        .arg(flag("delimiter").help(
+            "The delimiter used in the CSV file to separate key and value in each line. \
+             This defaults to ','.",));
 
     let node = cmd("node", ABOUT_NODE)
         .arg(pos("input").required(true).help("The FST to inspect."))

--- a/fst-bin/src/util.rs
+++ b/fst-bin/src/util.rs
@@ -135,15 +135,16 @@ impl Iterator for ConcatLines {
 pub struct ConcatCsv {
     inputs: Vec<PathBuf>,
     cur: Option<Rows>,
+    delimiter: u8,
 }
 
 type Reader = Box<dyn io::Read + Send + Sync + 'static>;
 type Rows = csv::DeserializeRecordsIntoIter<Reader, (BString, u64)>;
 
 impl ConcatCsv {
-    pub fn new(mut inputs: Vec<PathBuf>) -> ConcatCsv {
+    pub fn new(mut inputs: Vec<PathBuf>, delimiter: u8) -> ConcatCsv {
         inputs.reverse(); // treat it as a stack
-        ConcatCsv { inputs, cur: None }
+        ConcatCsv { inputs, cur: None, delimiter }
     }
 
     fn read_row(&mut self) -> Option<Result<(BString, u64), Error>> {
@@ -173,6 +174,7 @@ impl Iterator for ConcatCsv {
                             Ok(rdr) => rdr,
                         };
                         let csvrdr = csv::ReaderBuilder::new()
+                            .delimiter(self.delimiter)
                             .has_headers(false)
                             .from_reader(rdr);
                         self.cur = Some(csvrdr.into_deserialize());


### PR DESCRIPTION
This commandline option allows to specify the delimiter between keys and the values in the input file to the `map` subcommand.

The provided delimiter should be a single byte utf-8 character. If the value consists of multiple bytes only the first one is used. This parameter is passed to `csv::ReaderBuilder::delimiter` which only allows for a single byte as delimiter.

# Motivation
This is motivated by a colon used as separator between the keys and values. Fundamentaly resulting in issue #146, as I needed to write my own generator binary (where I missed the call to `finish`). With this option I would not have needed to use a custom implementation or could have used the official binary to compare the behaviour.