### PR TITLE
Making code runnable directly + remove unused code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,11 +52,11 @@ This requires the `levenshtein` feature in this crate to be enabled. It is not
 enabled by default.
 
 ```rust
-use fst::{IntoStreamer, Streamer, Set};
+use fst::{IntoStreamer Set};
 use fst::automaton::Levenshtein;
 
 # fn main() { example().unwrap(); }
-fn example() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     // A convenient way to create sets in memory.
     let keys = vec!["fa", "fo", "fob", "focus", "foo", "food", "foul"];
     let set = Set::from_iter(keys)?;
@@ -65,7 +65,7 @@ fn example() -> Result<(), Box<dyn std::error::Error>> {
     let lev = Levenshtein::new("foo", 1)?;
 
     // Apply our fuzzy query to the set we built.
-    let mut stream = set.search(lev).into_stream();
+    let stream = set.search(lev).into_stream();
 
     let keys = stream.into_strs()?;
     assert_eq!(keys, vec!["fo", "fob", "foo", "food"]);


### PR DESCRIPTION
Make the code runnable directly after copy+pasting into Rust Playground or local `main.rs` file.

Also removed redundant code that compiler warns about being unused.