### PR TITLE
Add next_start_node function to Stream

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -716,6 +716,11 @@ impl<'a, 'm, A: Automaton> Streamer<'a> for Stream<'m, A> {
     fn next(&'a mut self) -> Option<(&'a [u8], u64)> {
         self.0.next().map(|(key, out)| (key, out.value()))
     }
+
+    #[inline]
+    fn next_start_node(&'a self) -> Option<raw::Node<'_>> {
+        self.0.next_start_node()
+    }
 }
 
 impl<'m, A: Automaton> Stream<'m, A> {
@@ -781,6 +786,11 @@ where
     fn next(&'a mut self) -> Option<(&'a [u8], u64, A::State)> {
         self.0.next().map(|(key, out, state)| (key, out.value(), state))
     }
+
+    #[inline]
+    fn next_start_node(&'a self) -> Option<raw::Node<'_>> {
+        self.0.next_start_node()
+    }
 }
 
 /// A lexicographically ordered stream of keys from a map.
@@ -794,6 +804,11 @@ impl<'a, 'm> Streamer<'a> for Keys<'m> {
     #[inline]
     fn next(&'a mut self) -> Option<&'a [u8]> {
         self.0.next().map(|(key, _)| key)
+    }
+
+    #[inline]
+    fn next_start_node(&'a self) -> Option<raw::Node<'_>> {
+        self.0.next_start_node()
     }
 }
 
@@ -809,6 +824,11 @@ impl<'a, 'm> Streamer<'a> for Values<'m> {
     #[inline]
     fn next(&'a mut self) -> Option<u64> {
         self.0.next().map(|(_, out)| out.value())
+    }
+
+    #[inline]
+    fn next_start_node(&'a self) -> Option<raw::Node<'_>> {
+        self.0.next_start_node()
     }
 }
 
@@ -1201,6 +1221,11 @@ impl<'a, 'm> Streamer<'a> for Union<'m> {
     fn next(&'a mut self) -> Option<(&'a [u8], &'a [IndexedValue])> {
         self.0.next()
     }
+
+    #[inline]
+    fn next_start_node(&'a self) -> Option<raw::Node<'_>> {
+        self.0.next_start_node()
+    }
 }
 
 /// A stream of set intersection over multiple map streams in lexicographic
@@ -1215,6 +1240,11 @@ impl<'a, 'm> Streamer<'a> for Intersection<'m> {
     #[inline]
     fn next(&'a mut self) -> Option<(&'a [u8], &'a [IndexedValue])> {
         self.0.next()
+    }
+
+    #[inline]
+    fn next_start_node(&'a self) -> Option<raw::Node<'_>> {
+        self.0.next_start_node()
     }
 }
 
@@ -1235,6 +1265,11 @@ impl<'a, 'm> Streamer<'a> for Difference<'m> {
     fn next(&'a mut self) -> Option<(&'a [u8], &'a [IndexedValue])> {
         self.0.next()
     }
+
+    #[inline]
+    fn next_start_node(&'a self) -> Option<raw::Node<'_>> {
+        self.0.next_start_node()
+    }
 }
 
 /// A stream of set symmetric difference over multiple map streams in
@@ -1249,6 +1284,11 @@ impl<'a, 'm> Streamer<'a> for SymmetricDifference<'m> {
     #[inline]
     fn next(&'a mut self) -> Option<(&'a [u8], &'a [IndexedValue])> {
         self.0.next()
+    }
+
+    #[inline]
+    fn next_start_node(&'a self) -> Option<raw::Node<'_>> {
+        self.0.next_start_node()
     }
 }
 
@@ -1267,5 +1307,10 @@ where
 
     fn next(&'a mut self) -> Option<(&'a [u8], raw::Output)> {
         self.0.next().map(|(k, v)| (k, raw::Output::new(v)))
+    }
+
+    #[inline]
+    fn next_start_node(&'a self) -> Option<raw::Node<'_>> {
+        self.0.next_start_node()
     }
 }

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1050,6 +1050,10 @@ impl<'f, 'a, A: Automaton> Streamer<'a> for Stream<'f, A> {
     fn next(&'a mut self) -> Option<(&'a [u8], Output)> {
         self.0.next_with(|_| ()).map(|(key, out, _)| (key, out))
     }
+
+    fn next_start_node(&'a self) -> Option<Node<'_>> {
+        self.0.stack.last().map(|f| f.node)
+    }
 }
 
 /// A lexicographically ordered stream of key-value-state triples from an fst
@@ -1256,6 +1260,10 @@ where
 
     fn next(&'a mut self) -> Option<(&'a [u8], Output, A::State)> {
         self.next_with(|state| state.clone())
+    }
+
+    fn next_start_node(&'a self) -> Option<Node<'f>> {
+        self.stack.last().map(|f| f.node)
     }
 }
 

--- a/src/raw/ops.rs
+++ b/src/raw/ops.rs
@@ -229,6 +229,16 @@ impl<'a, 'f> Streamer<'a> for Union<'f> {
         }
         Some((slot.input(), &self.outs))
     }
+
+    fn next_start_node(&'a self) -> Option<super::Node<'_>> {
+        if let Some(ref slot) = self.cur_slot {
+            self.heap.next_start_node(slot)
+        } else if let Some(ref slot) = self.heap.heap.peek() {
+            self.heap.next_start_node(slot)
+        } else {
+            None
+        }
+    }
 }
 
 /// A stream of set intersection over multiple fst streams in lexicographic
@@ -268,6 +278,16 @@ impl<'a, 'f> Streamer<'a> for Intersection<'f> {
                 let key = self.cur_slot.as_ref().unwrap().input();
                 return Some((key, &self.outs));
             }
+        }
+    }
+
+    fn next_start_node(&'a self) -> Option<super::Node<'_>> {
+        if let Some(ref slot) = self.cur_slot {
+            self.heap.next_start_node(slot)
+        } else if let Some(ref slot) = self.heap.heap.peek() {
+            self.heap.next_start_node(slot)
+        } else {
+            None
         }
     }
 }
@@ -314,6 +334,10 @@ impl<'a, 'f> Streamer<'a> for Difference<'f> {
             }
         }
     }
+
+    fn next_start_node(&'a self) -> Option<super::Node<'_>> {
+        self.set.next_start_node()
+    }
 }
 
 /// A stream of set symmetric difference over multiple fst streams in
@@ -357,6 +381,16 @@ impl<'a, 'f> Streamer<'a> for SymmetricDifference<'f> {
             }
         }
     }
+
+    fn next_start_node(&'a self) -> Option<super::Node<'_>> {
+        if let Some(ref slot) = self.cur_slot {
+            self.heap.next_start_node(slot)
+        } else if let Some(ref slot) = self.heap.heap.peek() {
+            self.heap.next_start_node(slot)
+        } else {
+            None
+        }
+    }
 }
 
 struct StreamHeap<'f> {
@@ -375,6 +409,10 @@ impl<'f> StreamHeap<'f> {
 
     fn pop(&mut self) -> Option<Slot> {
         self.heap.pop()
+    }
+
+    fn next_start_node(&'f self, slot: &Slot) -> Option<super::Node<'f>> {
+        self.rdrs.get(slot.idx).and_then(|f| f.next_start_node())
     }
 
     fn peek_is_duplicate(&self, key: &[u8]) -> bool {

--- a/src/set.rs
+++ b/src/set.rs
@@ -666,6 +666,11 @@ impl<'a, 's, A: Automaton> Streamer<'a> for Stream<'s, A> {
     fn next(&'a mut self) -> Option<&'a [u8]> {
         self.0.next().map(|(key, _)| key)
     }
+
+    #[inline]
+    fn next_start_node(&'a self) -> Option<raw::Node<'_>> {
+        self.0.next_start_node()
+    }
 }
 
 /// A lexicographically ordered stream of key-state pairs from a set and
@@ -689,6 +694,11 @@ where
 
     fn next(&'a mut self) -> Option<(&'a [u8], A::State)> {
         self.0.next().map(|(key, _, state)| (key, state))
+    }
+
+    #[inline]
+    fn next_start_node(&'a self) -> Option<raw::Node<'_>> {
+        self.0.next_start_node()
     }
 }
 
@@ -1000,6 +1010,11 @@ impl<'a, 's> Streamer<'a> for Union<'s> {
     fn next(&'a mut self) -> Option<&'a [u8]> {
         self.0.next().map(|(key, _)| key)
     }
+
+    #[inline]
+    fn next_start_node(&'a self) -> Option<raw::Node<'_>> {
+        self.0.next_start_node()
+    }
 }
 
 /// A stream of set intersection over multiple streams in lexicographic order.
@@ -1013,6 +1028,11 @@ impl<'a, 's> Streamer<'a> for Intersection<'s> {
     #[inline]
     fn next(&'a mut self) -> Option<&'a [u8]> {
         self.0.next().map(|(key, _)| key)
+    }
+
+    #[inline]
+    fn next_start_node(&'a self) -> Option<raw::Node<'_>> {
+        self.0.next_start_node()
     }
 }
 
@@ -1032,6 +1052,11 @@ impl<'a, 's> Streamer<'a> for Difference<'s> {
     fn next(&'a mut self) -> Option<&'a [u8]> {
         self.0.next().map(|(key, _)| key)
     }
+
+    #[inline]
+    fn next_start_node(&'a self) -> Option<raw::Node<'_>> {
+        self.0.next_start_node()
+    }
 }
 
 /// A stream of set symmetric difference over multiple streams in lexicographic
@@ -1046,6 +1071,11 @@ impl<'a, 's> Streamer<'a> for SymmetricDifference<'s> {
     #[inline]
     fn next(&'a mut self) -> Option<&'a [u8]> {
         self.0.next().map(|(key, _)| key)
+    }
+
+    #[inline]
+    fn next_start_node(&'a self) -> Option<raw::Node<'_>> {
+        self.0.next_start_node()
     }
 }
 
@@ -1062,12 +1092,17 @@ impl<'a, S: Streamer<'a>> Streamer<'a> for StreamZeroOutput<S> {
     fn next(&'a mut self) -> Option<(S::Item, raw::Output)> {
         self.0.next().map(|key| (key, raw::Output::zero()))
     }
+
+    #[inline]
+    fn next_start_node(&'a self) -> Option<raw::Node<'_>> {
+        self.0.next_start_node()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::OpBuilder;
-    use crate::Streamer;
+    use crate::{raw, Streamer};
 
     #[test]
     fn no_fsts() {
@@ -1092,6 +1127,11 @@ mod tests {
                     self.i += 1;
                     Some(self.xs[i])
                 }
+            }
+
+            #[inline]
+            fn next_start_node(&'a self) -> Option<raw::Node<'_>> {
+                None
             }
         }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,3 +1,5 @@
+use crate::raw::Node;
+
 /// Streamer describes a "streaming iterator."
 ///
 /// It provides a mechanism for writing code that is generic over streams
@@ -104,6 +106,9 @@ pub trait Streamer<'a> {
     /// It is not specified what a stream does after `None` is emitted. In most
     /// cases, `None` should be emitted on every subsequent call.
     fn next(&'a mut self) -> Option<Self::Item>;
+
+    /// Returns the node that the next call to `Self::next` will start from.
+    fn next_start_node(&'a self) -> Option<Node<'_>>;
 }
 
 /// IntoStreamer describes types that can be converted to streams.


### PR DESCRIPTION
### What is this?
This adds a function to the `Stream` trait that allows you to see the current node that the `dyn Stream` will start from on the next call to `Stream::next`.

### My use case
I'm trying to use an fst to implement auto-completion in a file dialog. Basically, I put all the files and directories into an fst, then I traverse the fst to the current partial file/folder name, then based on if the node I end up on has only 1 transition or not, I decide to either partially, or completely, complete the file or directory that the user is looking for, if that condition is true.
![20230414_17h37m23s_grim](https://user-images.githubusercontent.com/57533634/232159299-ecbfdfa1-e99a-47ad-87ff-9d26e3bb42ee.png)
Or display a tooltip with the possible files/directories, if that condition is false
![20230414_17h33m43s_grim](https://user-images.githubusercontent.com/57533634/232158824-8388f21a-0397-4e57-afc8-02419fe0a72a.png)
In order to do this, I need to traverse the fst to find the node to check for transitions on, then I need to traverse it again to initialize the searching stream for the tooltip, which isn't ideal.
```rust
let mut node = self.root();

for &b in key {
    node = match node.find_input(b) {
        None => return false,
        Some(i) => self.node(node.transition_addr(i)),
    }
}

if !node.is_final() {
    if node.transitions().count() == 1 {
       /* Complete file name */
       while node.transitions().count() == 1 {
         let t = node.transitions().next().unwrap();
         self.path_edit.push(t.inp as char);
         node = self.completion.machine.node(t.addr);
       }
    } else {
       let matcher = fst::automaton::Str::new(file_name).starts_with();
       let mut stream = self
         .completion
         .machine
         .search(matcher)
         .gt(file_name)
         .into_stream();
        /* Traverse stream to display tooltip */
    }
}
```
What this PR does, is it allows you to just initialize the stream from the get-go, and then call `next_start_node` to find where we end up after initializing the stream with a range
```rust
let matcher = fst::automaton::Str::new(file_name).starts_with();
let mut stream = self
  .completion
  .machine
  .search(matcher)
  .gt(file_name)
  .into_stream();

if let Some(mut node) = stream.next_start_node() {
  if node.transitions().count() == 1 {
     /* Complete file name */
     while node.transitions().count() == 1 {
       let t = node.transitions().next().unwrap();
       self.path_edit.push(t.inp as char);
       node = self.completion.machine.node(t.addr);
     }
  } else {
    /* Traverse stream to display tooltip */
  }
}
```
This way, I only have to traverse the fst once, for both cases. And I don't have to start over for the tooltip case.