### PR TITLE
Quickcheck Gen update. 

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -131,19 +131,20 @@ pub fn pack_size(n: u64) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use quickcheck::{QuickCheck, StdGen};
+    use quickcheck::{QuickCheck, Gen};
     use std::io;
 
     #[test]
     fn prop_pack_in_out() {
         fn p(num: u64) -> bool {
+            let num = (num as u8) as u64; // restrict to 1-byte boundary
             let mut buf = io::Cursor::new(vec![]);
             let size = pack_uint(&mut buf, num).unwrap();
             buf.set_position(0);
             num == unpack_uint(buf.get_ref(), size)
         }
         QuickCheck::new()
-            .gen(StdGen::new(::rand::thread_rng(), 257)) // pick byte boundary
+            .gen(Gen::new(100)) // default size
             .quickcheck(p as fn(u64) -> bool);
     }
 }


### PR DESCRIPTION
This is an update of the test when quickcheck 1.0 when the patch https://github.com/BurntSushi/quickcheck/pull/278 is used. 