### PR TITLE
no_std support

### DIFF
--- a/.idea/fst.iml
+++ b/.idea/fst.iml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="EMPTY_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/bench/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/fst-bin/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/fst.iml" filepath="$PROJECT_DIR$/.idea/fst.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="CargoProjectFeatures">
+    <cargoProject file="$PROJECT_DIR$/Cargo.toml">
+      <package file="$PROJECT_DIR$">
+        <feature name="default" />
+        <feature name="std" />
+      </package>
+    </cargoProject>
+  </component>
+  <component name="CargoProjects">
+    <cargoProject FILE="$PROJECT_DIR$/Cargo.toml" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="2351eec2-10c6-4fe2-bf44-60f2a97fd618" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/Cargo.toml" beforeDir="false" afterPath="$PROJECT_DIR$/Cargo.toml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/automaton/levenshtein.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/automaton/levenshtein.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/bytes.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/bytes.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/error.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/error.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/lib.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/map.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/map.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/raw/build.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/raw/build.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/raw/counting_writer.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/raw/counting_writer.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/raw/error.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/raw/error.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/raw/mod.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/raw/mod.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/raw/node.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/raw/node.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/raw/ops.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/raw/ops.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/raw/registry.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/raw/registry.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/raw/registry_minimal.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/raw/registry_minimal.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/set.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/set.rs" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="MacroExpansionManager">
+    <option name="directoryName" value="2abe9j1i" />
+  </component>
+  <component name="MarkdownSettingsMigration">
+    <option name="stateVersion" value="1" />
+  </component>
+  <component name="ProjectColorInfo">{
+  &quot;associatedIndex&quot;: 6
+}</component>
+  <component name="ProjectId" id="2XUh6xqVt8KaHiuDZe5bJwFyBLP" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+    <option name="showScratchesAndConsoles" value="false" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "git-widget-placeholder": "master",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "org.rust.cargo.project.model.PROJECT_DISCOVERY": "true",
+    "vue.rearranger.settings.migration": "true"
+  }
+}]]></component>
+  <component name="RunManager" selected="Cargo.Test fst">
+    <configuration name="Run fst" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+      <option name="command" value="run --package fst-bin --bin fst" />
+      <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+      <option name="emulateTerminal" value="true" />
+      <option name="channel" value="DEFAULT" />
+      <option name="requiredFeatures" value="true" />
+      <option name="allFeatures" value="false" />
+      <option name="withSudo" value="false" />
+      <option name="buildTarget" value="REMOTE" />
+      <option name="backtrace" value="SHORT" />
+      <envs />
+      <option name="isRedirectInput" value="false" />
+      <option name="redirectInputPath" value="" />
+      <method v="2">
+        <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+      </method>
+    </configuration>
+    <configuration name="Test fst" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+      <option name="command" value="test --workspace" />
+      <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+      <option name="emulateTerminal" value="true" />
+      <option name="channel" value="DEFAULT" />
+      <option name="requiredFeatures" value="true" />
+      <option name="allFeatures" value="false" />
+      <option name="withSudo" value="false" />
+      <option name="buildTarget" value="REMOTE" />
+      <option name="backtrace" value="SHORT" />
+      <envs />
+      <option name="isRedirectInput" value="false" />
+      <option name="redirectInputPath" value="" />
+      <method v="2">
+        <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+      </method>
+    </configuration>
+  </component>
+  <component name="RustProjectSettings">
+    <option name="toolchainHomeDirectory" value="$USER_HOME$/.cargo/bin" />
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="2351eec2-10c6-4fe2-bf44-60f2a97fd618" name="Changes" comment="" />
+      <created>1698689393828</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1698689393828</updated>
+      <workItem from="1698689394895" duration="1651000" />
+      <workItem from="1698762835283" duration="108000" />
+      <workItem from="1698762948508" duration="6172000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+</project>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,10 @@ members = ["bench", "fst-bin"]
 exclude = ["fst-levenshtein", "fst-regex"]
 
 [features]
-default = []
+default = ["std"]
 levenshtein = ["utf8-ranges"]
+std = ["alloc"]
+alloc = []
 
 [patch.crates-io]
 fst = { path = "." }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,6 @@ levenshtein = ["utf8-ranges"]
 std = ["alloc"]
 alloc = []
 
-[patch.crates-io]
-fst = { path = "." }
-
 [dependencies]
 utf8-ranges = { version = "1.0.4", optional = true }
 

--- a/src/automaton/levenshtein.rs
+++ b/src/automaton/levenshtein.rs
@@ -1,7 +1,9 @@
-use std::cmp;
-use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet};
-use std::fmt;
+use core::cmp;
+use core::fmt;
+#[cfg(feature = "alloc")]
+use alloc::collections::hash_map::Entry;
+#[cfg(feature = "alloc")]
+use alloc::collections::{HashMap, HashSet};
 
 use utf8_ranges::{Utf8Range, Utf8Sequences};
 
@@ -34,7 +36,7 @@ impl fmt::Display for LevenshteinError {
     }
 }
 
-impl std::error::Error for LevenshteinError {}
+impl core::error::Error for LevenshteinError {}
 
 /// A Unicode aware Levenshtein automaton for running efficient fuzzy queries.
 ///
@@ -92,11 +94,13 @@ impl std::error::Error for LevenshteinError {}
 ///
 /// This is important functionality, so one should count on this implementation
 /// being vastly improved in the future.
+#[cfg(feature = "alloc")]
 pub struct Levenshtein {
     prog: DynamicLevenshtein,
     dfa: Dfa,
 }
 
+#[cfg(feature = "alloc")]
 impl Levenshtein {
     /// Create a new Levenshtein query.
     ///
@@ -109,6 +113,7 @@ impl Levenshtein {
     ///
     /// A `Levenshtein` value satisfies the `Automaton` trait, which means it
     /// can be used with the `search` method of any finite state transducer.
+    #[cfg(feature = "alloc")]
     pub fn new(
         query: &str,
         distance: u32,
@@ -132,6 +137,7 @@ impl Levenshtein {
     ///
     /// A `Levenshtein` value satisfies the `Automaton` trait, which means it
     /// can be used with the `search` method of any finite state transducer.
+    #[cfg(feature = "alloc")]
     pub fn new_with_limit(
         query: &str,
         distance: u32,
@@ -147,6 +153,7 @@ impl Levenshtein {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl fmt::Debug for Levenshtein {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -158,11 +165,13 @@ impl fmt::Debug for Levenshtein {
 }
 
 #[derive(Clone)]
+#[cfg(feature = "alloc")]
 struct DynamicLevenshtein {
     query: String,
     dist: usize,
 }
 
+#[cfg(feature = "alloc")]
 impl DynamicLevenshtein {
     fn start(&self) -> Vec<usize> {
         (0..self.query.chars().count() + 1).collect()
@@ -190,6 +199,7 @@ impl DynamicLevenshtein {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl Automaton for Levenshtein {
     type State = Option<usize>;
 
@@ -215,6 +225,7 @@ impl Automaton for Levenshtein {
 }
 
 #[derive(Debug)]
+#[cfg(feature = "alloc")]
 struct Dfa {
     states: Vec<State>,
 }
@@ -237,12 +248,14 @@ impl fmt::Debug for State {
     }
 }
 
+#[cfg(feature = "alloc")]
 struct DfaBuilder {
     dfa: Dfa,
     lev: DynamicLevenshtein,
     cache: HashMap<Vec<usize>, usize>,
 }
 
+#[cfg(feature = "alloc")]
 impl DfaBuilder {
     fn new(lev: DynamicLevenshtein) -> DfaBuilder {
         DfaBuilder {

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1,4 +1,5 @@
-use std::convert::TryInto;
+use core::convert::TryInto;
+#[cfg(feature = "std")]
 use std::io;
 
 /// Read a u32 in little endian format from the beginning of the given slice.
@@ -30,6 +31,7 @@ pub fn write_u32_le(n: u32, slice: &mut [u8]) {
 /// Like write_u32_le, but to an io::Write implementation. If every byte could
 /// not be writen, then this returns an error.
 #[inline]
+#[cfg(feature = "std")]
 pub fn io_write_u32_le<W: io::Write>(n: u32, mut wtr: W) -> io::Result<()> {
     let mut buf = [0; 4];
     write_u32_le(n, &mut buf);
@@ -55,6 +57,7 @@ pub fn write_u64_le(n: u64, slice: &mut [u8]) {
 /// Like write_u64_le, but to an io::Write implementation. If every byte could
 /// not be writen, then this returns an error.
 #[inline]
+#[cfg(feature = "std")]
 pub fn io_write_u64_le<W: io::Write>(n: u64, mut wtr: W) -> io::Result<()> {
     let mut buf = [0; 8];
     write_u64_le(n, &mut buf);
@@ -65,6 +68,7 @@ pub fn io_write_u64_le<W: io::Write>(n: u64, mut wtr: W) -> io::Result<()> {
 /// and writes it to the given writer. The number of bytes written is returned
 /// on success.
 #[inline]
+#[cfg(feature = "std")]
 pub fn pack_uint<W: io::Write>(wtr: W, n: u64) -> io::Result<u8> {
     let nbytes = pack_size(n);
     pack_uint_in(wtr, n, nbytes).map(|_| nbytes)
@@ -76,6 +80,7 @@ pub fn pack_uint<W: io::Write>(wtr: W, n: u64) -> io::Result<u8> {
 /// `nbytes` must be >= pack_size(n) and <= 8, where `pack_size(n)` is the
 /// smallest number of bytes that can store the integer given.
 #[inline]
+#[cfg(feature = "std")]
 pub fn pack_uint_in<W: io::Write>(
     mut wtr: W,
     mut n: u64,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,16 @@
-use std::fmt;
+use core::fmt;
+#[cfg(feature = "std")]
 use std::io;
 
 use crate::raw;
 
 /// A `Result` type alias for this crate's `Error` type.
+#[cfg(feature = "std")]
 pub type Result<T> = std::result::Result<T, Error>;
+
+/// A `Result` type alias for this crate's `Error` type.
+#[cfg(not(feature = "std"))]
+pub type Result<T> = core::result::Result<T, Error>;
 
 /// An error that encapsulates all possible errors in this crate.
 #[derive(Debug)]
@@ -13,9 +19,11 @@ pub enum Error {
     /// transducer.
     Fst(raw::Error),
     /// An IO error that occurred while writing a finite state transducer.
+    #[cfg(feature = "std")]
     Io(io::Error),
 }
 
+#[cfg(feature = "std")]
 impl From<io::Error> for Error {
     #[inline]
     fn from(err: io::Error) -> Error {
@@ -34,15 +42,29 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Error::Fst(_) => write!(f, "FST error"),
+            #[cfg(feature = "std")]
             Error::Io(_) => write!(f, "I/O error"),
         }
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match *self {
             Error::Fst(ref err) => Some(err),
+            #[cfg(feature = "std")]
+            Error::Io(ref err) => Some(err),
+        }
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl core::error::Error for Error {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match *self {
+            Error::Fst(ref err) => Some(err),
+            #[cfg(feature = "std")]
             Error::Io(ref err) => Some(err),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,15 +299,24 @@ data structures found in the standard library, such as `BTreeSet` and
    `fst-bin/src/merge.rs` from the root of this crate's repository.
 */
 
+#![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]
+#![cfg_attr(not(feature = "std"), feature(error_in_core))]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 #[cfg(all(feature = "levenshtein", doctest))]
 doc_comment::doctest!("../README.md");
 
 pub use crate::automaton::Automaton;
 pub use crate::error::{Error, Result};
-pub use crate::map::{Map, MapBuilder};
-pub use crate::set::{Set, SetBuilder};
+pub use crate::map::Map;
+#[cfg(feature = "alloc")]
+pub use crate::map::MapBuilder;
+pub use crate::set::Set;
+#[cfg(feature = "alloc")]
+pub use crate::set::SetBuilder;
 pub use crate::stream::{IntoStreamer, Streamer};
 
 mod bytes;

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,12 +1,20 @@
-use std::fmt;
+#[cfg(feature = "alloc")]
+use core::fmt;
+#[cfg(feature = "std")]
 use std::io;
-use std::iter::{self, FromIterator};
+#[cfg(feature = "alloc")]
+use core::iter::{self, FromIterator};
 
+#[cfg(feature = "alloc")]
 use crate::automaton::{AlwaysMatch, Automaton};
 use crate::raw;
 pub use crate::raw::IndexedValue;
-use crate::stream::{IntoStreamer, Streamer};
+#[cfg(feature = "alloc")]
+use crate::stream::IntoStreamer;
+use crate::stream::Streamer;
 use crate::Result;
+#[cfg(feature = "alloc")]
+use alloc::{vec::Vec, string::String};
 
 /// Map is a lexicographically ordered map from byte strings to integers.
 ///
@@ -54,6 +62,7 @@ use crate::Result;
 #[derive(Clone)]
 pub struct Map<D>(raw::Fst<D>);
 
+#[cfg(feature = "alloc")]
 impl Map<Vec<u8>> {
     /// Create a `Map` from an iterator of lexicographically ordered byte
     /// strings and associated values.
@@ -64,6 +73,7 @@ impl Map<Vec<u8>> {
     /// Note that this is a convenience function to build a map in memory.
     /// To build a map that streams to an arbitrary `io::Write`, use
     /// `MapBuilder`.
+    #[cfg(feature = "std")]
     pub fn from_iter<K, I>(iter: I) -> Result<Map<Vec<u8>>>
     where
         K: AsRef<[u8]>,
@@ -167,6 +177,7 @@ impl<D: AsRef<[u8]>> Map<D> {
     /// ]);
     /// ```
     #[inline]
+    #[cfg(feature = "alloc")]
     pub fn stream(&self) -> Stream<'_> {
         Stream(self.0.stream())
     }
@@ -190,6 +201,7 @@ impl<D: AsRef<[u8]>> Map<D> {
     /// assert_eq!(keys, vec![b"a", b"b", b"c"]);
     /// ```
     #[inline]
+    #[cfg(feature = "alloc")]
     pub fn keys(&self) -> Keys<'_> {
         Keys(self.0.stream())
     }
@@ -214,6 +226,7 @@ impl<D: AsRef<[u8]>> Map<D> {
     /// assert_eq!(values, vec![1, 2, 3]);
     /// ```
     #[inline]
+    #[cfg(feature = "alloc")]
     pub fn values(&self) -> Values<'_> {
         Values(self.0.stream())
     }
@@ -250,6 +263,7 @@ impl<D: AsRef<[u8]>> Map<D> {
     /// ]);
     /// ```
     #[inline]
+    #[cfg(feature = "alloc")]
     pub fn range(&self) -> StreamBuilder<'_> {
         StreamBuilder(self.0.range())
     }
@@ -301,6 +315,7 @@ impl<D: AsRef<[u8]>> Map<D> {
     ///     Ok(())
     /// }
     /// ```
+    #[cfg(feature = "alloc")]
     pub fn search<A: Automaton>(&self, aut: A) -> StreamBuilder<'_, A> {
         StreamBuilder(self.0.search(aut))
     }
@@ -354,6 +369,7 @@ fn example() -> Result<(), Box<dyn std::error::Error>> {
 ```
 "##
     )]
+    #[cfg(feature = "alloc")]
     pub fn search_with_state<A: Automaton>(
         &self,
         aut: A,
@@ -417,6 +433,7 @@ fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// ]);
     /// ```
     #[inline]
+    #[cfg(feature = "alloc")]
     pub fn op(&self) -> OpBuilder<'_> {
         OpBuilder::new().add(self)
     }
@@ -462,6 +479,7 @@ fn example() -> Result<(), Box<dyn std::error::Error>> {
     }
 }
 
+#[cfg(feature = "std")]
 impl Default for Map<Vec<u8>> {
     #[inline]
     fn default() -> Map<Vec<u8>> {
@@ -469,6 +487,7 @@ impl Default for Map<Vec<u8>> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<D: AsRef<[u8]>> fmt::Debug for Map<D> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Map([")?;
@@ -501,6 +520,7 @@ impl<D: AsRef<[u8]>> AsRef<raw::Fst<D>> for Map<D> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'m, 'a, D: AsRef<[u8]>> IntoStreamer<'a> for &'m Map<D> {
     type Item = (&'a [u8], u64);
     type Into = Stream<'m>;
@@ -606,8 +626,10 @@ impl<'m, 'a, D: AsRef<[u8]>> IntoStreamer<'a> for &'m Map<D> {
 ///     (b"stevie".to_vec(), 3),
 /// ]);
 /// ```
+#[cfg(feature = "alloc")]
 pub struct MapBuilder<W>(raw::Builder<W>);
 
+#[cfg(feature = "std")]
 impl MapBuilder<Vec<u8>> {
     /// Create a builder that builds a map in memory.
     #[inline]
@@ -622,6 +644,7 @@ impl MapBuilder<Vec<u8>> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<W: io::Write> MapBuilder<W> {
     /// Create a builder that builds a map by writing it to `wtr` in a
     /// streaming fashion.
@@ -706,10 +729,12 @@ impl<W: io::Write> MapBuilder<W> {
 /// the stream. By default, no filtering is done.
 ///
 /// The `'m` lifetime parameter refers to the lifetime of the underlying map.
+#[cfg(feature = "alloc")]
 pub struct Stream<'m, A = AlwaysMatch>(raw::Stream<'m, A>)
 where
     A: Automaton;
 
+#[cfg(feature = "alloc")]
 impl<'a, 'm, A: Automaton> Streamer<'a> for Stream<'m, A> {
     type Item = (&'a [u8], u64);
 
@@ -718,6 +743,7 @@ impl<'a, 'm, A: Automaton> Streamer<'a> for Stream<'m, A> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'m, A: Automaton> Stream<'m, A> {
     /// Convert this stream into a vector of byte strings and outputs.
     ///
@@ -768,10 +794,12 @@ impl<'m, A: Automaton> Stream<'m, A> {
 /// the stream. By default, no filtering is done.
 ///
 /// The `'m` lifetime parameter refers to the lifetime of the underlying map.
+#[cfg(feature = "alloc")]
 pub struct StreamWithState<'m, A = AlwaysMatch>(raw::StreamWithState<'m, A>)
 where
     A: Automaton;
 
+#[cfg(feature = "alloc")]
 impl<'a, 'm, A: 'a + Automaton> Streamer<'a> for StreamWithState<'m, A>
 where
     A::State: Clone,
@@ -786,8 +814,10 @@ where
 /// A lexicographically ordered stream of keys from a map.
 ///
 /// The `'m` lifetime parameter refers to the lifetime of the underlying map.
+#[cfg(feature = "alloc")]
 pub struct Keys<'m>(raw::Stream<'m>);
 
+#[cfg(feature = "alloc")]
 impl<'a, 'm> Streamer<'a> for Keys<'m> {
     type Item = &'a [u8];
 
@@ -801,8 +831,10 @@ impl<'a, 'm> Streamer<'a> for Keys<'m> {
 /// corresponding key.
 ///
 /// The `'m` lifetime parameter refers to the lifetime of the underlying map.
+#[cfg(feature = "alloc")]
 pub struct Values<'m>(raw::Stream<'m>);
 
+#[cfg(feature = "alloc")]
 impl<'a, 'm> Streamer<'a> for Values<'m> {
     type Item = u64;
 
@@ -824,8 +856,10 @@ impl<'a, 'm> Streamer<'a> for Values<'m> {
 /// the stream. By default, no filtering is done.
 ///
 /// The `'m` lifetime parameter refers to the lifetime of the underlying map.
+#[cfg(feature = "alloc")]
 pub struct StreamBuilder<'m, A = AlwaysMatch>(raw::StreamBuilder<'m, A>);
 
+#[cfg(feature = "alloc")]
 impl<'m, A: Automaton> StreamBuilder<'m, A> {
     /// Specify a greater-than-or-equal-to bound.
     pub fn ge<T: AsRef<[u8]>>(self, bound: T) -> StreamBuilder<'m, A> {
@@ -847,6 +881,8 @@ impl<'m, A: Automaton> StreamBuilder<'m, A> {
         StreamBuilder(self.0.lt(bound))
     }
 }
+
+#[cfg(feature = "alloc")]
 
 impl<'m, 'a, A: Automaton> IntoStreamer<'a> for StreamBuilder<'m, A> {
     type Item = (&'a [u8], u64);
@@ -874,10 +910,12 @@ impl<'m, 'a, A: Automaton> IntoStreamer<'a> for StreamBuilder<'m, A> {
 /// the stream. By default, no filtering is done.
 ///
 /// The `'m` lifetime parameter refers to the lifetime of the underlying map.
+#[cfg(feature = "alloc")]
 pub struct StreamWithStateBuilder<'m, A = AlwaysMatch>(
     raw::StreamWithStateBuilder<'m, A>,
 );
 
+#[cfg(feature = "alloc")]
 impl<'m, A: Automaton> StreamWithStateBuilder<'m, A> {
     /// Specify a greater-than-or-equal-to bound.
     pub fn ge<T: AsRef<[u8]>>(
@@ -912,6 +950,7 @@ impl<'m, A: Automaton> StreamWithStateBuilder<'m, A> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'m, 'a, A: 'a + Automaton> IntoStreamer<'a>
     for StreamWithStateBuilder<'m, A>
 where
@@ -942,8 +981,10 @@ where
 /// stream.
 ///
 /// The `'m` lifetime parameter refers to the lifetime of the underlying set.
+#[cfg(feature = "alloc")]
 pub struct OpBuilder<'m>(raw::OpBuilder<'m>);
 
+#[cfg(feature = "alloc")]
 impl<'m> OpBuilder<'m> {
     /// Create a new set operation builder.
     #[inline]
@@ -1159,6 +1200,7 @@ impl<'m> OpBuilder<'m> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'f, I, S> Extend<I> for OpBuilder<'f>
 where
     I: for<'a> IntoStreamer<'a, Into = S, Item = (&'a [u8], u64)>,
@@ -1174,6 +1216,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'f, I, S> FromIterator<I> for OpBuilder<'f>
 where
     I: for<'a> IntoStreamer<'a, Into = S, Item = (&'a [u8], u64)>,
@@ -1192,8 +1235,10 @@ where
 /// A stream of set union over multiple map streams in lexicographic order.
 ///
 /// The `'m` lifetime parameter refers to the lifetime of the underlying map.
+#[cfg(feature = "alloc")]
 pub struct Union<'m>(raw::Union<'m>);
 
+#[cfg(feature = "alloc")]
 impl<'a, 'm> Streamer<'a> for Union<'m> {
     type Item = (&'a [u8], &'a [IndexedValue]);
 
@@ -1207,8 +1252,10 @@ impl<'a, 'm> Streamer<'a> for Union<'m> {
 /// order.
 ///
 /// The `'m` lifetime parameter refers to the lifetime of the underlying map.
+#[cfg(feature = "alloc")]
 pub struct Intersection<'m>(raw::Intersection<'m>);
 
+#[cfg(feature = "alloc")]
 impl<'a, 'm> Streamer<'a> for Intersection<'m> {
     type Item = (&'a [u8], &'a [IndexedValue]);
 
@@ -1226,8 +1273,10 @@ impl<'a, 'm> Streamer<'a> for Intersection<'m> {
 /// appear in any other streams.
 ///
 /// The `'m` lifetime parameter refers to the lifetime of the underlying map.
+#[cfg(feature = "alloc")]
 pub struct Difference<'m>(raw::Difference<'m>);
 
+#[cfg(feature = "alloc")]
 impl<'a, 'm> Streamer<'a> for Difference<'m> {
     type Item = (&'a [u8], &'a [IndexedValue]);
 
@@ -1241,8 +1290,10 @@ impl<'a, 'm> Streamer<'a> for Difference<'m> {
 /// lexicographic order.
 ///
 /// The `'m` lifetime parameter refers to the lifetime of the underlying map.
+#[cfg(feature = "alloc")]
 pub struct SymmetricDifference<'m>(raw::SymmetricDifference<'m>);
 
+#[cfg(feature = "alloc")]
 impl<'a, 'm> Streamer<'a> for SymmetricDifference<'m> {
     type Item = (&'a [u8], &'a [IndexedValue]);
 

--- a/src/raw/build.rs
+++ b/src/raw/build.rs
@@ -1,16 +1,29 @@
+#[cfg(feature = "std")]
 use std::io;
-
+#[cfg(feature = "std")]
 use crate::bytes;
+#[cfg(feature = "std")]
 use crate::error::Result;
+#[cfg(feature = "alloc")]
 use crate::raw::counting_writer::CountingWriter;
+#[cfg(feature = "std")]
 use crate::raw::error::Error;
-use crate::raw::registry::{Registry, RegistryEntry};
+#[cfg(feature = "alloc")]
+use crate::raw::registry::Registry;
+#[cfg(feature = "std")]
+use crate::raw::registry::RegistryEntry;
+use crate::raw::Output;
+#[cfg(feature = "alloc")]
+use crate::raw::{CompiledAddr, Fst, Transition};
+#[cfg(feature = "std")]
 use crate::raw::{
-    CompiledAddr, Fst, FstType, Output, Transition, EMPTY_ADDRESS,
+     FstType, EMPTY_ADDRESS,
     NONE_ADDRESS, VERSION,
 };
-// use raw::registry_minimal::{Registry, RegistryEntry};
+#[cfg(feature = "std")]
 use crate::stream::{IntoStreamer, Streamer};
+#[cfg(feature = "alloc")]
+use alloc::{vec::Vec, vec};
 
 /// A builder for creating a finite state transducer.
 ///
@@ -40,6 +53,7 @@ use crate::stream::{IntoStreamer, Streamer};
 ///
 /// The algorithmic complexity of fst construction is `O(n)` where `n` is the
 /// number of elements added to the fst.
+#[cfg(feature = "alloc")]
 pub struct Builder<W> {
     /// The FST raw data is written directly to `wtr`.
     ///
@@ -73,17 +87,20 @@ pub struct Builder<W> {
 }
 
 #[derive(Debug)]
+#[cfg(feature = "alloc")]
 struct UnfinishedNodes {
     stack: Vec<BuilderNodeUnfinished>,
 }
 
 #[derive(Debug)]
+#[cfg(feature = "alloc")]
 struct BuilderNodeUnfinished {
     node: BuilderNode,
     last: Option<LastTransition>,
 }
 
 #[derive(Debug, Hash, Eq, PartialEq)]
+#[cfg(feature = "alloc")]
 pub struct BuilderNode {
     pub is_final: bool,
     pub final_output: Output,
@@ -96,6 +113,7 @@ struct LastTransition {
     out: Output,
 }
 
+#[cfg(feature = "std")]
 impl Builder<Vec<u8>> {
     /// Create a builder that builds an fst in memory.
     #[inline]
@@ -110,6 +128,7 @@ impl Builder<Vec<u8>> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<W: io::Write> Builder<W> {
     /// Create a builder that builds an fst by writing it to `wtr` in a
     /// streaming fashion.
@@ -325,6 +344,7 @@ impl<W: io::Write> Builder<W> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl UnfinishedNodes {
     fn new() -> UnfinishedNodes {
         let mut unfinished = UnfinishedNodes { stack: Vec::with_capacity(64) };
@@ -422,6 +442,7 @@ impl UnfinishedNodes {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl BuilderNodeUnfinished {
     fn last_compiled(&mut self, addr: CompiledAddr) {
         if let Some(trans) = self.last.take() {
@@ -446,6 +467,7 @@ impl BuilderNodeUnfinished {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl Clone for BuilderNode {
     fn clone(&self) -> BuilderNode {
         BuilderNode {
@@ -463,6 +485,7 @@ impl Clone for BuilderNode {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl Default for BuilderNode {
     fn default() -> BuilderNode {
         BuilderNode {

--- a/src/raw/counting_writer.rs
+++ b/src/raw/counting_writer.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "std")]
 use std::io;
 
 use crate::raw::crc32::CheckSummer;
@@ -9,6 +10,7 @@ pub struct CountingWriter<W> {
     summer: CheckSummer,
 }
 
+#[cfg(feature = "std")]
 impl<W: io::Write> CountingWriter<W> {
     /// Wrap the given writer with a counter.
     pub fn new(wtr: W) -> CountingWriter<W> {
@@ -43,6 +45,7 @@ impl<W: io::Write> CountingWriter<W> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<W: io::Write> io::Write for CountingWriter<W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.summer.update(buf);

--- a/src/raw/node.rs
+++ b/src/raw/node.rs
@@ -1,9 +1,12 @@
-use std::cmp;
-use std::fmt;
+#[cfg(feature = "std")]
+use core::cmp;
+use core::fmt;
+#[cfg(feature = "std")]
 use std::io;
-use std::ops::Range;
+use core::ops::Range;
 
 use crate::bytes;
+#[cfg(feature = "std")]
 use crate::raw::build::BuilderNode;
 use crate::raw::common_inputs::{COMMON_INPUTS, COMMON_INPUTS_INV};
 use crate::raw::{
@@ -241,6 +244,7 @@ impl<'f> Node<'f> {
         }
     }
 
+    #[cfg(feature = "std")]
     fn compile<W: io::Write>(
         wtr: W,
         last_addr: CompiledAddr,
@@ -265,6 +269,7 @@ impl<'f> Node<'f> {
     }
 }
 
+#[cfg(feature = "std")]
 impl BuilderNode {
     pub fn compile_to<W: io::Write>(
         &self,
@@ -309,6 +314,7 @@ impl State {
 }
 
 impl StateOneTransNext {
+    #[cfg(feature = "std")]
     fn compile<W: io::Write>(
         mut wtr: W,
         _: CompiledAddr,
@@ -368,6 +374,7 @@ impl StateOneTransNext {
 }
 
 impl StateOneTrans {
+    #[cfg(feature = "std")]
     fn compile<W: io::Write>(
         mut wtr: W,
         addr: CompiledAddr,
@@ -466,6 +473,7 @@ impl StateOneTrans {
 }
 
 impl StateAnyTrans {
+    #[cfg(feature = "std")]
     fn compile<W: io::Write>(
         mut wtr: W,
         addr: CompiledAddr,
@@ -824,6 +832,7 @@ fn common_input(idx: u8) -> Option<u8> {
 }
 
 #[inline]
+#[cfg(feature = "std")]
 fn pack_delta<W: io::Write>(
     wtr: W,
     node_addr: CompiledAddr,
@@ -835,6 +844,7 @@ fn pack_delta<W: io::Write>(
 }
 
 #[inline]
+#[cfg(feature = "std")]
 fn pack_delta_in<W: io::Write>(
     wtr: W,
     node_addr: CompiledAddr,

--- a/src/raw/ops.rs
+++ b/src/raw/ops.rs
@@ -1,11 +1,15 @@
-use std::cmp;
-use std::collections::BinaryHeap;
-use std::iter::FromIterator;
+use core::cmp;
+#[cfg(feature = "alloc")]
+use alloc::{collections::BinaryHeap, boxed::Box};
+#[cfg(feature = "alloc")]
+use alloc::{vec, vec::Vec};
+use core::iter::FromIterator;
 
 use crate::raw::Output;
 use crate::stream::{IntoStreamer, Streamer};
 
 /// Permits stream operations to be hetergeneous with respect to streams.
+#[cfg(feature = "alloc")]
 type BoxedStream<'f> =
     Box<dyn for<'a> Streamer<'a, Item = (&'a [u8], Output)> + 'f>;
 
@@ -41,10 +45,12 @@ pub struct IndexedValue {
 /// stream.
 ///
 /// The `'f` lifetime parameter refers to the lifetime of the underlying set.
+#[cfg(feature = "alloc")]
 pub struct OpBuilder<'f> {
     streams: Vec<BoxedStream<'f>>,
 }
 
+#[cfg(feature = "alloc")]
 impl<'f> OpBuilder<'f> {
     /// Create a new set operation builder.
     #[inline]
@@ -168,6 +174,7 @@ impl<'f> OpBuilder<'f> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'f, I, S> Extend<I> for OpBuilder<'f>
 where
     I: for<'a> IntoStreamer<'a, Into = S, Item = (&'a [u8], Output)>,
@@ -183,6 +190,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'f, I, S> FromIterator<I> for OpBuilder<'f>
 where
     I: for<'a> IntoStreamer<'a, Into = S, Item = (&'a [u8], Output)>,
@@ -201,12 +209,14 @@ where
 /// A stream of set union over multiple fst streams in lexicographic order.
 ///
 /// The `'f` lifetime parameter refers to the lifetime of the underlying map.
+#[cfg(feature = "alloc")]
 pub struct Union<'f> {
     heap: StreamHeap<'f>,
     outs: Vec<IndexedValue>,
     cur_slot: Option<Slot>,
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, 'f> Streamer<'a> for Union<'f> {
     type Item = (&'a [u8], &'a [IndexedValue]);
 
@@ -235,12 +245,14 @@ impl<'a, 'f> Streamer<'a> for Union<'f> {
 /// order.
 ///
 /// The `'f` lifetime parameter refers to the lifetime of the underlying fst.
+#[cfg(feature = "alloc")]
 pub struct Intersection<'f> {
     heap: StreamHeap<'f>,
     outs: Vec<IndexedValue>,
     cur_slot: Option<Slot>,
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, 'f> Streamer<'a> for Intersection<'f> {
     type Item = (&'a [u8], &'a [IndexedValue]);
 
@@ -280,6 +292,7 @@ impl<'a, 'f> Streamer<'a> for Intersection<'f> {
 /// appear in any other streams.
 ///
 /// The `'f` lifetime parameter refers to the lifetime of the underlying fst.
+#[cfg(feature = "alloc")]
 pub struct Difference<'f> {
     set: BoxedStream<'f>,
     key: Vec<u8>,
@@ -287,6 +300,7 @@ pub struct Difference<'f> {
     outs: Vec<IndexedValue>,
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, 'f> Streamer<'a> for Difference<'f> {
     type Item = (&'a [u8], &'a [IndexedValue]);
 
@@ -320,12 +334,14 @@ impl<'a, 'f> Streamer<'a> for Difference<'f> {
 /// lexicographic order.
 ///
 /// The `'f` lifetime parameter refers to the lifetime of the underlying fst.
+#[cfg(feature = "alloc")]
 pub struct SymmetricDifference<'f> {
     heap: StreamHeap<'f>,
     outs: Vec<IndexedValue>,
     cur_slot: Option<Slot>,
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, 'f> Streamer<'a> for SymmetricDifference<'f> {
     type Item = (&'a [u8], &'a [IndexedValue]);
 
@@ -359,11 +375,13 @@ impl<'a, 'f> Streamer<'a> for SymmetricDifference<'f> {
     }
 }
 
+#[cfg(feature = "alloc")]
 struct StreamHeap<'f> {
     rdrs: Vec<BoxedStream<'f>>,
     heap: BinaryHeap<Slot>,
 }
 
+#[cfg(feature = "alloc")]
 impl<'f> StreamHeap<'f> {
     fn new(streams: Vec<BoxedStream<'f>>) -> StreamHeap<'f> {
         let mut u = StreamHeap { rdrs: streams, heap: BinaryHeap::new() };
@@ -410,6 +428,7 @@ impl<'f> StreamHeap<'f> {
     }
 }
 
+#[cfg(feature = "alloc")]
 #[derive(Debug, Eq, PartialEq)]
 struct Slot {
     idx: usize,
@@ -417,6 +436,7 @@ struct Slot {
     output: Output,
 }
 
+#[cfg(feature = "alloc")]
 impl Slot {
     fn new(rdr_idx: usize) -> Slot {
         Slot {
@@ -444,6 +464,7 @@ impl Slot {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl PartialOrd for Slot {
     fn partial_cmp(&self, other: &Slot) -> Option<cmp::Ordering> {
         (&self.input, self.output)
@@ -452,6 +473,7 @@ impl PartialOrd for Slot {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl Ord for Slot {
     fn cmp(&self, other: &Slot) -> cmp::Ordering {
         self.partial_cmp(other).unwrap()

--- a/src/raw/registry.rs
+++ b/src/raw/registry.rs
@@ -1,7 +1,10 @@
+#[cfg(feature = "alloc")]
 use crate::raw::build::BuilderNode;
 use crate::raw::{CompiledAddr, NONE_ADDRESS};
-
+#[cfg(feature = "alloc")]
+use alloc::{vec::Vec, vec};
 #[derive(Debug)]
+#[cfg(feature = "alloc")]
 pub struct Registry {
     table: Vec<RegistryCell>,
     table_size: usize, // number of rows
@@ -9,23 +12,27 @@ pub struct Registry {
 }
 
 #[derive(Debug)]
+#[cfg(feature = "alloc")]
 struct RegistryCache<'a> {
     cells: &'a mut [RegistryCell],
 }
 
 #[derive(Clone, Debug)]
+#[cfg(feature = "alloc")]
 pub struct RegistryCell {
     addr: CompiledAddr,
     node: BuilderNode,
 }
 
 #[derive(Debug)]
+#[cfg(feature = "alloc")]
 pub enum RegistryEntry<'a> {
     Found(CompiledAddr),
     NotFound(&'a mut RegistryCell),
     Rejected,
 }
 
+#[cfg(feature = "alloc")]
 impl Registry {
     pub fn new(table_size: usize, mru_size: usize) -> Registry {
         let empty_cell = RegistryCell::none();
@@ -62,6 +69,7 @@ impl Registry {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> RegistryCache<'a> {
     fn entry(mut self, node: &BuilderNode) -> RegistryEntry<'a> {
         if self.cells.len() == 1 {
@@ -112,6 +120,7 @@ impl<'a> RegistryCache<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl RegistryCell {
     fn none() -> RegistryCell {
         RegistryCell { addr: NONE_ADDRESS, node: BuilderNode::default() }

--- a/src/raw/registry_minimal.rs
+++ b/src/raw/registry_minimal.rs
@@ -10,13 +10,14 @@
 // expensive SipHasher.
 
 #![allow(dead_code)]
-
+#[cfg(feature = "std")]
 use std::collections::hash_map::{Entry, HashMap};
-
+#[cfg(feature = "std")]
 use crate::raw::build::BuilderNode;
 use crate::raw::CompiledAddr;
 
 #[derive(Debug)]
+#[cfg(feature = "std")]
 pub struct Registry {
     table: HashMap<BuilderNode, RegistryCell>,
 }
@@ -31,6 +32,7 @@ pub enum RegistryEntry<'a> {
 #[derive(Clone, Copy, Debug)]
 pub struct RegistryCell(CompiledAddr);
 
+#[cfg(feature = "std")]
 impl Registry {
     pub fn new(table_size: usize, _lru_size: usize) -> Registry {
         Registry { table: HashMap::with_capacity(table_size) }

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,6 +1,10 @@
-use std::fmt;
+#[cfg(feature = "alloc")]
+use core::fmt;
+#[cfg(feature = "std")]
 use std::io;
-use std::iter::{self, FromIterator};
+use core::iter::{self, FromIterator};
+#[cfg(feature = "alloc")]
+use alloc::{vec::Vec, string::String};
 
 use crate::automaton::{AlwaysMatch, Automaton};
 use crate::raw;
@@ -29,6 +33,7 @@ use crate::Result;
 #[derive(Clone)]
 pub struct Set<D>(raw::Fst<D>);
 
+#[cfg(feature = "alloc")]
 impl Set<Vec<u8>> {
     /// Create a `Set` from an iterator of lexicographically ordered byte
     /// strings.
@@ -39,6 +44,7 @@ impl Set<Vec<u8>> {
     /// Note that this is a convenience function to build a set in memory.
     /// To build a set that streams to an arbitrary `io::Write`, use
     /// `SetBuilder`.
+    #[cfg(feature = "std")]
     pub fn from_iter<T, I>(iter: I) -> Result<Set<Vec<u8>>>
     where
         T: AsRef<[u8]>,
@@ -119,6 +125,7 @@ impl<D: AsRef<[u8]>> Set<D> {
     /// assert_eq!(keys, vec![b"a", b"b", b"c"]);
     /// ```
     #[inline]
+    #[cfg(feature = "alloc")]
     pub fn stream(&self) -> Stream<'_> {
         Stream(self.0.stream())
     }
@@ -149,6 +156,7 @@ impl<D: AsRef<[u8]>> Set<D> {
     /// assert_eq!(keys, vec![b"b", b"c", b"d"]);
     /// ```
     #[inline]
+    #[cfg(feature = "alloc")]
     pub fn range(&self) -> StreamBuilder<'_> {
         StreamBuilder(self.0.range())
     }
@@ -189,6 +197,7 @@ impl<D: AsRef<[u8]>> Set<D> {
     ///     Ok(())
     /// }
     /// ```
+    #[cfg(feature = "alloc")]
     pub fn search<A: Automaton>(&self, aut: A) -> StreamBuilder<'_, A> {
         StreamBuilder(self.0.search(aut))
     }
@@ -242,6 +251,7 @@ fn example() -> Result<(), Box<dyn std::error::Error>> {
 ```
 "##
     )]
+    #[cfg(feature = "alloc")]
     pub fn search_with_state<A: Automaton>(
         &self,
         aut: A,
@@ -284,6 +294,7 @@ fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// assert_eq!(keys, vec![b"a", b"b", b"c", b"y", b"z"]);
     /// ```
     #[inline]
+    #[cfg(feature = "alloc")]
     pub fn op(&self) -> OpBuilder<'_> {
         OpBuilder::new().add(self)
     }
@@ -307,6 +318,7 @@ fn example() -> Result<(), Box<dyn std::error::Error>> {
     ///
     /// assert_eq!(set1.is_disjoint(&set3), false);
     /// ```
+    #[cfg(feature = "alloc")]
     pub fn is_disjoint<'f, I, S>(&self, stream: I) -> bool
     where
         I: for<'a> IntoStreamer<'a, Into = S, Item = &'a [u8]>,
@@ -334,6 +346,7 @@ fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// assert_eq!(set1.is_subset(&set3), false);
     /// assert_eq!(set3.is_subset(&set1), true);
     /// ```
+    #[cfg(feature = "alloc")]
     pub fn is_subset<'f, I, S>(&self, stream: I) -> bool
     where
         I: for<'a> IntoStreamer<'a, Into = S, Item = &'a [u8]>,
@@ -361,6 +374,7 @@ fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// assert_eq!(set1.is_superset(&set3), true);
     /// assert_eq!(set3.is_superset(&set1), false);
     /// ```
+    #[cfg(feature = "alloc")]
     pub fn is_superset<'f, I, S>(&self, stream: I) -> bool
     where
         I: for<'a> IntoStreamer<'a, Into = S, Item = &'a [u8]>,
@@ -410,6 +424,7 @@ fn example() -> Result<(), Box<dyn std::error::Error>> {
     }
 }
 
+#[cfg(feature = "std")]
 impl Default for Set<Vec<u8>> {
     #[inline]
     fn default() -> Set<Vec<u8>> {
@@ -417,6 +432,7 @@ impl Default for Set<Vec<u8>> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<D: AsRef<[u8]>> fmt::Debug for Set<D> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Set([")?;
@@ -441,6 +457,7 @@ impl<D: AsRef<[u8]>> AsRef<raw::Fst<D>> for Set<D> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'s, 'a, D: AsRef<[u8]>> IntoStreamer<'a> for &'s Set<D> {
     type Item = &'a [u8];
     type Into = Stream<'s>;
@@ -548,8 +565,10 @@ impl<D: AsRef<[u8]>> From<raw::Fst<D>> for Set<D> {
 ///     "bruce".as_bytes(), "clarence".as_bytes(), "stevie".as_bytes(),
 /// ]);
 /// ```
+#[cfg(feature = "alloc")]
 pub struct SetBuilder<W>(raw::Builder<W>);
 
+#[cfg(feature = "std")]
 impl SetBuilder<Vec<u8>> {
     /// Create a builder that builds a set in memory.
     #[inline]
@@ -564,6 +583,7 @@ impl SetBuilder<Vec<u8>> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<W: io::Write> SetBuilder<W> {
     /// Create a builder that builds a set by writing it to `wtr` in a
     /// streaming fashion.
@@ -637,10 +657,12 @@ impl<W: io::Write> SetBuilder<W> {
 /// the stream. By default, no filtering is done.
 ///
 /// The `'s` lifetime parameter refers to the lifetime of the underlying set.
+#[cfg(feature = "alloc")]
 pub struct Stream<'s, A = AlwaysMatch>(raw::Stream<'s, A>)
 where
     A: Automaton;
 
+#[cfg(feature = "alloc")]
 impl<'s, A: Automaton> Stream<'s, A> {
     /// Convert this stream into a vector of Unicode strings.
     ///
@@ -660,6 +682,7 @@ impl<'s, A: Automaton> Stream<'s, A> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, 's, A: Automaton> Streamer<'a> for Stream<'s, A> {
     type Item = &'a [u8];
 
@@ -677,10 +700,12 @@ impl<'a, 's, A: Automaton> Streamer<'a> for Stream<'s, A> {
 /// the stream. By default, no filtering is done.
 ///
 /// The `'m` lifetime parameter refers to the lifetime of the underlying set.
+#[cfg(feature = "alloc")]
 pub struct StreamWithState<'m, A = AlwaysMatch>(raw::StreamWithState<'m, A>)
 where
     A: Automaton;
 
+#[cfg(feature = "alloc")]
 impl<'a, 'm, A: 'a + Automaton> Streamer<'a> for StreamWithState<'m, A>
 where
     A::State: Clone,
@@ -704,8 +729,10 @@ where
 /// the stream. By default, no filtering is done.
 ///
 /// The `'s` lifetime parameter refers to the lifetime of the underlying set.
+#[cfg(feature = "alloc")]
 pub struct StreamBuilder<'s, A = AlwaysMatch>(raw::StreamBuilder<'s, A>);
 
+#[cfg(feature = "alloc")]
 impl<'s, A: Automaton> StreamBuilder<'s, A> {
     /// Specify a greater-than-or-equal-to bound.
     pub fn ge<T: AsRef<[u8]>>(self, bound: T) -> StreamBuilder<'s, A> {
@@ -728,6 +755,7 @@ impl<'s, A: Automaton> StreamBuilder<'s, A> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'s, 'a, A: Automaton> IntoStreamer<'a> for StreamBuilder<'s, A> {
     type Item = &'a [u8];
     type Into = Stream<'s, A>;
@@ -754,10 +782,12 @@ impl<'s, 'a, A: Automaton> IntoStreamer<'a> for StreamBuilder<'s, A> {
 /// the stream. By default, no filtering is done.
 ///
 /// The `'s` lifetime parameter refers to the lifetime of the underlying set.
+#[cfg(feature = "alloc")]
 pub struct StreamWithStateBuilder<'s, A = AlwaysMatch>(
     raw::StreamWithStateBuilder<'s, A>,
 );
 
+#[cfg(feature = "alloc")]
 impl<'s, A: Automaton> StreamWithStateBuilder<'s, A> {
     /// Specify a greater-than-or-equal-to bound.
     pub fn ge<T: AsRef<[u8]>>(
@@ -792,6 +822,7 @@ impl<'s, A: Automaton> StreamWithStateBuilder<'s, A> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'s, 'a, A: 'a + Automaton> IntoStreamer<'a>
     for StreamWithStateBuilder<'s, A>
 where
@@ -819,8 +850,10 @@ where
 /// stream.
 ///
 /// The `'s` lifetime parameter refers to the lifetime of the underlying set.
+#[cfg(feature = "alloc")]
 pub struct OpBuilder<'s>(raw::OpBuilder<'s>);
 
+#[cfg(feature = "alloc")]
 impl<'s> OpBuilder<'s> {
     /// Create a new set operation builder.
     #[inline]
@@ -958,6 +991,7 @@ impl<'s> OpBuilder<'s> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'f, I, S> Extend<I> for OpBuilder<'f>
 where
     I: for<'a> IntoStreamer<'a, Into = S, Item = &'a [u8]>,
@@ -973,6 +1007,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'f, I, S> FromIterator<I> for OpBuilder<'f>
 where
     I: for<'a> IntoStreamer<'a, Into = S, Item = &'a [u8]>,
@@ -991,8 +1026,10 @@ where
 /// A stream of set union over multiple streams in lexicographic order.
 ///
 /// The `'s` lifetime parameter refers to the lifetime of the underlying set.
+#[cfg(feature = "alloc")]
 pub struct Union<'s>(raw::Union<'s>);
 
+#[cfg(feature = "alloc")]
 impl<'a, 's> Streamer<'a> for Union<'s> {
     type Item = &'a [u8];
 
@@ -1005,8 +1042,10 @@ impl<'a, 's> Streamer<'a> for Union<'s> {
 /// A stream of set intersection over multiple streams in lexicographic order.
 ///
 /// The `'s` lifetime parameter refers to the lifetime of the underlying set.
+#[cfg(feature = "alloc")]
 pub struct Intersection<'s>(raw::Intersection<'s>);
 
+#[cfg(feature = "alloc")]
 impl<'a, 's> Streamer<'a> for Intersection<'s> {
     type Item = &'a [u8];
 
@@ -1023,8 +1062,10 @@ impl<'a, 's> Streamer<'a> for Intersection<'s> {
 /// appear in any other streams.
 ///
 /// The `'s` lifetime parameter refers to the lifetime of the underlying set.
+#[cfg(feature = "alloc")]
 pub struct Difference<'s>(raw::Difference<'s>);
 
+#[cfg(feature = "alloc")]
 impl<'a, 's> Streamer<'a> for Difference<'s> {
     type Item = &'a [u8];
 
@@ -1038,8 +1079,10 @@ impl<'a, 's> Streamer<'a> for Difference<'s> {
 /// order.
 ///
 /// The `'s` lifetime parameter refers to the lifetime of the underlying set.
+#[cfg(feature = "alloc")]
 pub struct SymmetricDifference<'s>(raw::SymmetricDifference<'s>);
 
+#[cfg(feature = "alloc")]
 impl<'a, 's> Streamer<'a> for SymmetricDifference<'s> {
     type Item = &'a [u8];
 


### PR DESCRIPTION
This PR adds two feature flags `std` and `alloc` (both of which are enabled by default) allowing this crate to be used in no_std contexts such as embedded (or wasm if you want to optimize the file size really aggressively like me).

This works because the basic fst query operations such as `get` and `contains` actually do not allocate at all and building the actual fst can be done in a build script in most situations.
 
`std` only really enables features that depend on `io::Write` while most of the fst functions (all construction and complex query types) are gated behind `alloc`

I made this change mostly for myself, but thought I might as well volunteer it for inclusion even though the macros and conditional includes do complicate the codebase a fair bit I think it's a neat addition. 


