### PR TITLE
Add ε-serde support (no change to the code)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ levenshtein = ["utf8-ranges"]
 fst = { path = "." }
 
 [dependencies]
+epserde = { git = "https://github.com/vigna/epserde", optional = true }
 utf8-ranges = { version = "1.0.4", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ levenshtein = ["utf8-ranges"]
 fst = { path = "." }
 
 [dependencies]
-epserde = { git = "https://github.com/vigna/epserde", optional = true }
+epserde = { version = "0.13.0", optional = true }
 utf8-ranges = { version = "1.0.4", optional = true }
 
 [dev-dependencies]

--- a/src/automaton/levenshtein.rs
+++ b/src/automaton/levenshtein.rs
@@ -92,6 +92,7 @@ impl std::error::Error for LevenshteinError {}
 ///
 /// This is important functionality, so one should count on this implementation
 /// being vastly improved in the future.
+#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
 pub struct Levenshtein {
     prog: DynamicLevenshtein,
     dfa: Dfa,
@@ -158,6 +159,7 @@ impl fmt::Debug for Levenshtein {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
 struct DynamicLevenshtein {
     query: String,
     dist: usize,
@@ -215,10 +217,12 @@ impl Automaton for Levenshtein {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
 struct Dfa {
     states: Vec<State>,
 }
 
+#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
 struct State {
     next: [Option<usize>; 256],
     is_match: bool,

--- a/src/automaton/mod.rs
+++ b/src/automaton/mod.rs
@@ -179,15 +179,6 @@ impl<'a> Str<&'a [u8]> {
     }
 }
 
-impl<D> Str<D> {
-    /// Constructs an automaton that matches an exact byte string, from any
-    /// container that can be viewed as `&[u8]` (e.g. `Vec<u8>`, `&[u8]`).
-    #[inline]
-    pub fn from_bytes(string: D) -> Str<D> {
-        Str { string }
-    }
-}
-
 impl<D: AsRef<[u8]>> Automaton for Str<D> {
     type State = Option<usize>;
 
@@ -259,16 +250,6 @@ impl<'a> Subsequence<&'a [u8]> {
     #[inline]
     pub fn new(subsequence: &'a str) -> Subsequence<&'a [u8]> {
         Subsequence { subseq: subsequence.as_bytes() }
-    }
-}
-
-impl<D> Subsequence<D> {
-    /// Constructs an automaton that matches input containing the specified
-    /// byte subsequence, from any container that can be viewed as `&[u8]`
-    /// (e.g. `Vec<u8>`, `&[u8]`).
-    #[inline]
-    pub fn from_bytes(subsequence: D) -> Subsequence<D> {
-        Subsequence { subseq: subsequence }
     }
 }
 

--- a/src/automaton/mod.rs
+++ b/src/automaton/mod.rs
@@ -166,19 +166,29 @@ impl<'a, T: Automaton> Automaton for &'a T {
 /// }
 /// ```
 #[derive(Clone, Debug)]
-pub struct Str<'a> {
-    string: &'a [u8],
+#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
+pub struct Str<D = Vec<u8>> {
+    string: D,
 }
 
-impl<'a> Str<'a> {
+impl<'a> Str<&'a [u8]> {
     /// Constructs automaton that matches an exact string.
     #[inline]
-    pub fn new(string: &'a str) -> Str<'a> {
+    pub fn new(string: &'a str) -> Str<&'a [u8]> {
         Str { string: string.as_bytes() }
     }
 }
 
-impl<'a> Automaton for Str<'a> {
+impl<D> Str<D> {
+    /// Constructs an automaton that matches an exact byte string, from any
+    /// container that can be viewed as `&[u8]` (e.g. `Vec<u8>`, `&[u8]`).
+    #[inline]
+    pub fn from_bytes(string: D) -> Str<D> {
+        Str { string }
+    }
+}
+
+impl<D: AsRef<[u8]>> Automaton for Str<D> {
     type State = Option<usize>;
 
     #[inline]
@@ -188,7 +198,7 @@ impl<'a> Automaton for Str<'a> {
 
     #[inline]
     fn is_match(&self, pos: &Option<usize>) -> bool {
-        *pos == Some(self.string.len())
+        *pos == Some(self.string.as_ref().len())
     }
 
     #[inline]
@@ -201,7 +211,7 @@ impl<'a> Automaton for Str<'a> {
         // if we aren't already past the end...
         if let Some(pos) = *pos {
             // and there is still a matching byte at the current position...
-            if self.string.get(pos).cloned() == Some(byte) {
+            if self.string.as_ref().get(pos).cloned() == Some(byte) {
                 // then move forward
                 return Some(pos + 1);
             }
@@ -238,20 +248,31 @@ impl<'a> Automaton for Str<'a> {
 /// }
 /// ```
 #[derive(Clone, Debug)]
-pub struct Subsequence<'a> {
-    subseq: &'a [u8],
+#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
+pub struct Subsequence<D = Vec<u8>> {
+    subseq: D,
 }
 
-impl<'a> Subsequence<'a> {
+impl<'a> Subsequence<&'a [u8]> {
     /// Constructs automaton that matches input containing the
     /// specified subsequence.
     #[inline]
-    pub fn new(subsequence: &'a str) -> Subsequence<'a> {
+    pub fn new(subsequence: &'a str) -> Subsequence<&'a [u8]> {
         Subsequence { subseq: subsequence.as_bytes() }
     }
 }
 
-impl<'a> Automaton for Subsequence<'a> {
+impl<D> Subsequence<D> {
+    /// Constructs an automaton that matches input containing the specified
+    /// byte subsequence, from any container that can be viewed as `&[u8]`
+    /// (e.g. `Vec<u8>`, `&[u8]`).
+    #[inline]
+    pub fn from_bytes(subsequence: D) -> Subsequence<D> {
+        Subsequence { subseq: subsequence }
+    }
+}
+
+impl<D: AsRef<[u8]>> Automaton for Subsequence<D> {
     type State = usize;
 
     #[inline]
@@ -261,7 +282,7 @@ impl<'a> Automaton for Subsequence<'a> {
 
     #[inline]
     fn is_match(&self, &state: &usize) -> bool {
-        state == self.subseq.len()
+        state == self.subseq.as_ref().len()
     }
 
     #[inline]
@@ -271,15 +292,16 @@ impl<'a> Automaton for Subsequence<'a> {
 
     #[inline]
     fn will_always_match(&self, &state: &usize) -> bool {
-        state == self.subseq.len()
+        state == self.subseq.as_ref().len()
     }
 
     #[inline]
     fn accept(&self, &state: &usize, byte: u8) -> usize {
-        if state == self.subseq.len() {
+        let subseq = self.subseq.as_ref();
+        if state == subseq.len() {
             return state;
         }
-        state + (byte == self.subseq[state]) as usize
+        state + (byte == subseq[state]) as usize
     }
 }
 
@@ -288,6 +310,7 @@ impl<'a> Automaton for Subsequence<'a> {
 /// This is useful in a generic context as a way to express that no automaton
 /// should be used.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
 pub struct AlwaysMatch;
 
 impl Automaton for AlwaysMatch {
@@ -318,6 +341,7 @@ impl Automaton for AlwaysMatch {
 /// An automaton that matches a string that begins with something that the
 /// wrapped automaton matches.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
 pub struct StartsWith<A>(A);
 
 /// The `Automaton` state for `StartsWith<A>`.
@@ -384,6 +408,7 @@ impl<A: Automaton> Automaton for StartsWith<A> {
 
 /// An automaton that matches when one of its component automata match.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
 pub struct Union<A, B>(A, B);
 
 /// The `Automaton` state for `Union<A, B>`.
@@ -419,6 +444,7 @@ impl<A: Automaton, B: Automaton> Automaton for Union<A, B> {
 
 /// An automaton that matches when both of its component automata match.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
 pub struct Intersection<A, B>(A, B);
 
 /// The `Automaton` state for `Intersection<A, B>`.
@@ -458,6 +484,7 @@ impl<A: Automaton, B: Automaton> Automaton for Intersection<A, B> {
 
 /// An automaton that matches exactly when the automaton it wraps does not.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
 pub struct Complement<A>(A);
 
 /// The `Automaton` state for `Complement<A>`.

--- a/src/automaton/mod.rs
+++ b/src/automaton/mod.rs
@@ -212,7 +212,7 @@ impl<'a> Automaton for Str<'a> {
 }
 
 #[cfg(feature = "epserde")]
-mod epserde {
+mod epserde_impls {
     use super::*;
     use ::epserde::prelude::{
         deser::deser_eps_slice_zero,
@@ -247,7 +247,6 @@ mod epserde {
     impl<'a> SerInner for Str<'a> {
         type SerType = Str<'a>;
         const IS_ZERO_COPY: bool = false;
-        const MIGHT_BE_ZERO_COPY: bool = false;
         unsafe fn _ser_inner(
             &self,
             backend: &mut impl ser::WriteWithNames,
@@ -276,6 +275,65 @@ mod epserde {
             backend: &mut SliceWithPos<'c>,
         ) -> deser::Result<Self::DeserType<'c>> {
             unsafe { Ok(Str { string: deser_eps_slice_zero(backend)? }) }
+        }
+    }
+
+    unsafe impl<'a> CopyType for Subsequence<'a> {
+        type Copy = Deep;
+    }
+
+    impl<'a> TypeHash for Subsequence<'a> {
+        fn type_hash(hasher: &mut impl core::hash::Hasher) {
+            "DeepCopy".hash(hasher);
+            "automaton".hash(hasher);
+            "Subsequence".hash(hasher);
+            "0".hash(hasher);
+            <SerType<&[u8]>>::type_hash(hasher);
+        }
+    }
+
+    impl<'a> AlignHash for Subsequence<'a> {
+        fn align_hash(
+            hasher: &mut impl core::hash::Hasher,
+            _offset_of: &mut usize,
+        ) {
+            <SerType<&[u8]> as AlignHash>::align_hash(hasher, &mut 0);
+        }
+    }
+
+    impl<'a> SerInner for Subsequence<'a> {
+        type SerType = Subsequence<'a>;
+        const IS_ZERO_COPY: bool = false;
+        unsafe fn _ser_inner(
+            &self,
+            backend: &mut impl ser::WriteWithNames,
+        ) -> ser::Result<()> {
+            WriteWithNames::write(backend, "0", &self.subseq)
+        }
+    }
+
+    impl<'a> DeserInner for Subsequence<'a> {
+        type DeserType<'b> = Subsequence<'b>;
+
+        fn __check_covariance<'__long: '__short, '__short>(
+            proof: epserde::deser::CovariantProof<Self::DeserType<'__long>>,
+        ) -> epserde::deser::CovariantProof<Self::DeserType<'__short>>
+        {
+            proof
+        }
+
+        unsafe fn _deser_full_inner(
+            _backend: &mut impl ReadWithPos,
+        ) -> deser::Result<Self> {
+            unimplemented!();
+        }
+
+        unsafe fn _deser_eps_inner<'c>(
+            backend: &mut SliceWithPos<'c>,
+        ) -> deser::Result<Self::DeserType<'c>> {
+            unsafe {
+                Ok(Subsequence { subseq: deser_eps_slice_zero(backend)? })
+            }
         }
     }
 }
@@ -357,6 +415,7 @@ impl<'a> Automaton for Subsequence<'a> {
 /// This is useful in a generic context as a way to express that no automaton
 /// should be used.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
 pub struct AlwaysMatch;
 
 impl Automaton for AlwaysMatch {
@@ -387,6 +446,7 @@ impl Automaton for AlwaysMatch {
 /// An automaton that matches a string that begins with something that the
 /// wrapped automaton matches.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
 pub struct StartsWith<A>(A);
 
 /// The `Automaton` state for `StartsWith<A>`.
@@ -453,6 +513,7 @@ impl<A: Automaton> Automaton for StartsWith<A> {
 
 /// An automaton that matches when one of its component automata match.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
 pub struct Union<A, B>(A, B);
 
 /// The `Automaton` state for `Union<A, B>`.
@@ -488,6 +549,7 @@ impl<A: Automaton, B: Automaton> Automaton for Union<A, B> {
 
 /// An automaton that matches when both of its component automata match.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
 pub struct Intersection<A, B>(A, B);
 
 /// The `Automaton` state for `Intersection<A, B>`.
@@ -527,6 +589,7 @@ impl<A: Automaton, B: Automaton> Automaton for Intersection<A, B> {
 
 /// An automaton that matches exactly when the automaton it wraps does not.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
 pub struct Complement<A>(A);
 
 /// The `Automaton` state for `Complement<A>`.

--- a/src/automaton/mod.rs
+++ b/src/automaton/mod.rs
@@ -211,130 +211,82 @@ impl<'a> Automaton for Str<'a> {
     }
 }
 
+// ε-serde implementations for `Str`, which cannot be derived: `Str` borrows a
+// slice, and while `&[T]` implements `SerInner` it does not implement
+// `DeserInner.
 #[cfg(feature = "epserde")]
-mod epserde_impls {
-    use super::*;
-    use ::epserde::prelude::{
-        deser::deser_eps_slice_zero,
-        ser::{SerType, WriteWithNames},
-        *,
-    };
-    use core::hash::Hash;
+unsafe impl<'a> ::epserde::traits::CopyType for Str<'a> {
+    type Copy = ::epserde::traits::Deep;
+}
 
-    unsafe impl<'a> CopyType for Str<'a> {
-        type Copy = Deep;
+#[cfg(feature = "epserde")]
+impl<'a> ::epserde::ser::SerInner for Str<'a> {
+    type SerType = Str<'a>;
+    const IS_ZERO_COPY: bool = false;
+
+    unsafe fn _ser_inner(
+        &self,
+        backend: &mut impl ::epserde::ser::WriteWithNames,
+    ) -> ::epserde::ser::Result<()> {
+        use ::epserde::ser::WriteWithNames;
+        WriteWithNames::write(backend, "string", &self.string)
+    }
+}
+
+#[cfg(feature = "epserde")]
+impl<'a> ::epserde::deser::DeserInner for Str<'a> {
+    type DeserType<'b> = Str<'b>;
+
+    #[inline(always)]
+    fn __check_covariance<'__long: '__short, '__short>(
+        proof: ::epserde::deser::CovariantProof<Self::DeserType<'__long>>,
+    ) -> ::epserde::deser::CovariantProof<Self::DeserType<'__short>> {
+        proof
     }
 
-    impl<'a> TypeHash for Str<'a> {
-        fn type_hash(hasher: &mut impl core::hash::Hasher) {
-            "DeepCopy".hash(hasher);
-            "automaton".hash(hasher);
-            "S".hash(hasher);
-            "0".hash(hasher);
-            <SerType<&[u8]>>::type_hash(hasher);
-        }
+    unsafe fn _deser_full_inner(
+        _backend: &mut impl ::epserde::deser::ReadWithPos,
+    ) -> ::epserde::deser::Result<Self> {
+        // Unlike the derive, we cannot delegate to the field: there is nothing
+        // to own a fully deserialized slice.
+        unimplemented!();
     }
 
-    impl<'a> AlignHash for Str<'a> {
-        fn align_hash(
-            hasher: &mut impl core::hash::Hasher,
-            _offset_of: &mut usize,
-        ) {
-            <SerType<&[u8]> as AlignHash>::align_hash(hasher, &mut 0);
+    unsafe fn _deser_eps_inner<'b>(
+        backend: &mut ::epserde::deser::SliceWithPos<'b>,
+    ) -> ::epserde::deser::Result<Self::DeserType<'b>> {
+        // What `<Vec<u8> as DeserInner>::_deser_eps_inner` delegates to.
+        unsafe {
+            Ok(Str {
+                string: ::epserde::deser::deser_eps_slice_zero(backend)?,
+            })
         }
     }
+}
 
-    impl<'a> SerInner for Str<'a> {
-        type SerType = Str<'a>;
-        const IS_ZERO_COPY: bool = false;
-        unsafe fn _ser_inner(
-            &self,
-            backend: &mut impl ser::WriteWithNames,
-        ) -> ser::Result<()> {
-            WriteWithNames::write(backend, "0", &self.string)
-        }
+#[cfg(feature = "epserde")]
+impl<'a> ::epserde::traits::TypeHash for Str<'a> {
+    fn type_hash(hasher: &mut impl ::core::hash::Hasher) {
+        use ::core::hash::Hash;
+        use ::epserde::ser::SerType;
+        use ::epserde::traits::TypeHash;
+        Hash::hash("DeepCopy", hasher);
+        Hash::hash(::core::module_path!(), hasher);
+        Hash::hash("Str", hasher);
+        Hash::hash("string", hasher);
+        <SerType<&[u8]> as TypeHash>::type_hash(hasher);
     }
+}
 
-    impl<'a> DeserInner for Str<'a> {
-        type DeserType<'b> = Str<'b>;
-
-        fn __check_covariance<'__long: '__short, '__short>(
-            proof: epserde::deser::CovariantProof<Self::DeserType<'__long>>,
-        ) -> epserde::deser::CovariantProof<Self::DeserType<'__short>>
-        {
-            proof
-        }
-
-        unsafe fn _deser_full_inner(
-            _backend: &mut impl ReadWithPos,
-        ) -> deser::Result<Self> {
-            unimplemented!();
-        }
-
-        unsafe fn _deser_eps_inner<'c>(
-            backend: &mut SliceWithPos<'c>,
-        ) -> deser::Result<Self::DeserType<'c>> {
-            unsafe { Ok(Str { string: deser_eps_slice_zero(backend)? }) }
-        }
-    }
-
-    unsafe impl<'a> CopyType for Subsequence<'a> {
-        type Copy = Deep;
-    }
-
-    impl<'a> TypeHash for Subsequence<'a> {
-        fn type_hash(hasher: &mut impl core::hash::Hasher) {
-            "DeepCopy".hash(hasher);
-            "automaton".hash(hasher);
-            "Subsequence".hash(hasher);
-            "0".hash(hasher);
-            <SerType<&[u8]>>::type_hash(hasher);
-        }
-    }
-
-    impl<'a> AlignHash for Subsequence<'a> {
-        fn align_hash(
-            hasher: &mut impl core::hash::Hasher,
-            _offset_of: &mut usize,
-        ) {
-            <SerType<&[u8]> as AlignHash>::align_hash(hasher, &mut 0);
-        }
-    }
-
-    impl<'a> SerInner for Subsequence<'a> {
-        type SerType = Subsequence<'a>;
-        const IS_ZERO_COPY: bool = false;
-        unsafe fn _ser_inner(
-            &self,
-            backend: &mut impl ser::WriteWithNames,
-        ) -> ser::Result<()> {
-            WriteWithNames::write(backend, "0", &self.subseq)
-        }
-    }
-
-    impl<'a> DeserInner for Subsequence<'a> {
-        type DeserType<'b> = Subsequence<'b>;
-
-        fn __check_covariance<'__long: '__short, '__short>(
-            proof: epserde::deser::CovariantProof<Self::DeserType<'__long>>,
-        ) -> epserde::deser::CovariantProof<Self::DeserType<'__short>>
-        {
-            proof
-        }
-
-        unsafe fn _deser_full_inner(
-            _backend: &mut impl ReadWithPos,
-        ) -> deser::Result<Self> {
-            unimplemented!();
-        }
-
-        unsafe fn _deser_eps_inner<'c>(
-            backend: &mut SliceWithPos<'c>,
-        ) -> deser::Result<Self::DeserType<'c>> {
-            unsafe {
-                Ok(Subsequence { subseq: deser_eps_slice_zero(backend)? })
-            }
-        }
+#[cfg(feature = "epserde")]
+impl<'a> ::epserde::traits::AlignHash for Str<'a> {
+    fn align_hash(
+        hasher: &mut impl ::core::hash::Hasher,
+        _offset_of: &mut usize,
+    ) {
+        use ::epserde::ser::SerType;
+        use ::epserde::traits::AlignHash;
+        <SerType<&[u8]> as AlignHash>::align_hash(hasher, &mut 0);
     }
 }
 
@@ -407,6 +359,80 @@ impl<'a> Automaton for Subsequence<'a> {
             return state;
         }
         state + (byte == self.subseq[state]) as usize
+    }
+}
+
+// ε-serde implementations for `Subsequence`; see the ones for `Str` above.
+#[cfg(feature = "epserde")]
+unsafe impl<'a> ::epserde::traits::CopyType for Subsequence<'a> {
+    type Copy = ::epserde::traits::Deep;
+}
+
+#[cfg(feature = "epserde")]
+impl<'a> ::epserde::ser::SerInner for Subsequence<'a> {
+    type SerType = Subsequence<'a>;
+    const IS_ZERO_COPY: bool = false;
+
+    unsafe fn _ser_inner(
+        &self,
+        backend: &mut impl ::epserde::ser::WriteWithNames,
+    ) -> ::epserde::ser::Result<()> {
+        use ::epserde::ser::WriteWithNames;
+        WriteWithNames::write(backend, "subseq", &self.subseq)
+    }
+}
+
+#[cfg(feature = "epserde")]
+impl<'a> ::epserde::deser::DeserInner for Subsequence<'a> {
+    type DeserType<'b> = Subsequence<'b>;
+
+    #[inline(always)]
+    fn __check_covariance<'__long: '__short, '__short>(
+        proof: ::epserde::deser::CovariantProof<Self::DeserType<'__long>>,
+    ) -> ::epserde::deser::CovariantProof<Self::DeserType<'__short>> {
+        proof
+    }
+
+    unsafe fn _deser_full_inner(
+        _backend: &mut impl ::epserde::deser::ReadWithPos,
+    ) -> ::epserde::deser::Result<Self> {
+        unimplemented!();
+    }
+
+    unsafe fn _deser_eps_inner<'b>(
+        backend: &mut ::epserde::deser::SliceWithPos<'b>,
+    ) -> ::epserde::deser::Result<Self::DeserType<'b>> {
+        unsafe {
+            Ok(Subsequence {
+                subseq: ::epserde::deser::deser_eps_slice_zero(backend)?,
+            })
+        }
+    }
+}
+
+#[cfg(feature = "epserde")]
+impl<'a> ::epserde::traits::TypeHash for Subsequence<'a> {
+    fn type_hash(hasher: &mut impl ::core::hash::Hasher) {
+        use ::core::hash::Hash;
+        use ::epserde::ser::SerType;
+        use ::epserde::traits::TypeHash;
+        Hash::hash("DeepCopy", hasher);
+        Hash::hash(::core::module_path!(), hasher);
+        Hash::hash("Subsequence", hasher);
+        Hash::hash("subseq", hasher);
+        <SerType<&[u8]> as TypeHash>::type_hash(hasher);
+    }
+}
+
+#[cfg(feature = "epserde")]
+impl<'a> ::epserde::traits::AlignHash for Subsequence<'a> {
+    fn align_hash(
+        hasher: &mut impl ::core::hash::Hasher,
+        _offset_of: &mut usize,
+    ) {
+        use ::epserde::ser::SerType;
+        use ::epserde::traits::AlignHash;
+        <SerType<&[u8]> as AlignHash>::align_hash(hasher, &mut 0);
     }
 }
 

--- a/src/automaton/mod.rs
+++ b/src/automaton/mod.rs
@@ -166,20 +166,19 @@ impl<'a, T: Automaton> Automaton for &'a T {
 /// }
 /// ```
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
-pub struct Str<D = Vec<u8>> {
-    string: D,
+pub struct Str<'a> {
+    string: &'a [u8],
 }
 
-impl<'a> Str<&'a [u8]> {
+impl<'a> Str<'a> {
     /// Constructs automaton that matches an exact string.
     #[inline]
-    pub fn new(string: &'a str) -> Str<&'a [u8]> {
+    pub fn new(string: &'a str) -> Str<'a> {
         Str { string: string.as_bytes() }
     }
 }
 
-impl<D: AsRef<[u8]>> Automaton for Str<D> {
+impl<'a> Automaton for Str<'a> {
     type State = Option<usize>;
 
     #[inline]
@@ -189,7 +188,7 @@ impl<D: AsRef<[u8]>> Automaton for Str<D> {
 
     #[inline]
     fn is_match(&self, pos: &Option<usize>) -> bool {
-        *pos == Some(self.string.as_ref().len())
+        *pos == Some(self.string.len())
     }
 
     #[inline]
@@ -202,13 +201,82 @@ impl<D: AsRef<[u8]>> Automaton for Str<D> {
         // if we aren't already past the end...
         if let Some(pos) = *pos {
             // and there is still a matching byte at the current position...
-            if self.string.as_ref().get(pos).cloned() == Some(byte) {
+            if self.string.get(pos).cloned() == Some(byte) {
                 // then move forward
                 return Some(pos + 1);
             }
         }
         // otherwise we're either past the end or didn't match the byte
         None
+    }
+}
+
+#[cfg(feature = "epserde")]
+mod epserde {
+    use super::*;
+    use ::epserde::prelude::{
+        deser::deser_eps_slice_zero,
+        ser::{SerType, WriteWithNames},
+        *,
+    };
+    use core::hash::Hash;
+
+    unsafe impl<'a> CopyType for Str<'a> {
+        type Copy = Deep;
+    }
+
+    impl<'a> TypeHash for Str<'a> {
+        fn type_hash(hasher: &mut impl core::hash::Hasher) {
+            "DeepCopy".hash(hasher);
+            "automaton".hash(hasher);
+            "S".hash(hasher);
+            "0".hash(hasher);
+            <SerType<&[u8]>>::type_hash(hasher);
+        }
+    }
+
+    impl<'a> AlignHash for Str<'a> {
+        fn align_hash(
+            hasher: &mut impl core::hash::Hasher,
+            _offset_of: &mut usize,
+        ) {
+            <SerType<&[u8]> as AlignHash>::align_hash(hasher, &mut 0);
+        }
+    }
+
+    impl<'a> SerInner for Str<'a> {
+        type SerType = Str<'a>;
+        const IS_ZERO_COPY: bool = false;
+        const MIGHT_BE_ZERO_COPY: bool = false;
+        unsafe fn _ser_inner(
+            &self,
+            backend: &mut impl ser::WriteWithNames,
+        ) -> ser::Result<()> {
+            WriteWithNames::write(backend, "0", &self.string)
+        }
+    }
+
+    impl<'a> DeserInner for Str<'a> {
+        type DeserType<'b> = Str<'b>;
+
+        fn __check_covariance<'__long: '__short, '__short>(
+            proof: epserde::deser::CovariantProof<Self::DeserType<'__long>>,
+        ) -> epserde::deser::CovariantProof<Self::DeserType<'__short>>
+        {
+            proof
+        }
+
+        unsafe fn _deser_full_inner(
+            _backend: &mut impl ReadWithPos,
+        ) -> deser::Result<Self> {
+            unimplemented!();
+        }
+
+        unsafe fn _deser_eps_inner<'c>(
+            backend: &mut SliceWithPos<'c>,
+        ) -> deser::Result<Self::DeserType<'c>> {
+            unsafe { Ok(Str { string: deser_eps_slice_zero(backend)? }) }
+        }
     }
 }
 
@@ -239,21 +307,20 @@ impl<D: AsRef<[u8]>> Automaton for Str<D> {
 /// }
 /// ```
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
-pub struct Subsequence<D = Vec<u8>> {
-    subseq: D,
+pub struct Subsequence<'a> {
+    subseq: &'a [u8],
 }
 
-impl<'a> Subsequence<&'a [u8]> {
+impl<'a> Subsequence<'a> {
     /// Constructs automaton that matches input containing the
     /// specified subsequence.
     #[inline]
-    pub fn new(subsequence: &'a str) -> Subsequence<&'a [u8]> {
+    pub fn new(subsequence: &'a str) -> Subsequence<'a> {
         Subsequence { subseq: subsequence.as_bytes() }
     }
 }
 
-impl<D: AsRef<[u8]>> Automaton for Subsequence<D> {
+impl<'a> Automaton for Subsequence<'a> {
     type State = usize;
 
     #[inline]
@@ -263,7 +330,7 @@ impl<D: AsRef<[u8]>> Automaton for Subsequence<D> {
 
     #[inline]
     fn is_match(&self, &state: &usize) -> bool {
-        state == self.subseq.as_ref().len()
+        state == self.subseq.len()
     }
 
     #[inline]
@@ -273,16 +340,15 @@ impl<D: AsRef<[u8]>> Automaton for Subsequence<D> {
 
     #[inline]
     fn will_always_match(&self, &state: &usize) -> bool {
-        state == self.subseq.as_ref().len()
+        state == self.subseq.len()
     }
 
     #[inline]
     fn accept(&self, &state: &usize, byte: u8) -> usize {
-        let subseq = self.subseq.as_ref();
-        if state == subseq.len() {
+        if state == self.subseq.len() {
             return state;
         }
-        state + (byte == subseq[state]) as usize
+        state + (byte == self.subseq[state]) as usize
     }
 }
 
@@ -291,7 +357,6 @@ impl<D: AsRef<[u8]>> Automaton for Subsequence<D> {
 /// This is useful in a generic context as a way to express that no automaton
 /// should be used.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
 pub struct AlwaysMatch;
 
 impl Automaton for AlwaysMatch {
@@ -322,7 +387,6 @@ impl Automaton for AlwaysMatch {
 /// An automaton that matches a string that begins with something that the
 /// wrapped automaton matches.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
 pub struct StartsWith<A>(A);
 
 /// The `Automaton` state for `StartsWith<A>`.
@@ -389,7 +453,6 @@ impl<A: Automaton> Automaton for StartsWith<A> {
 
 /// An automaton that matches when one of its component automata match.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
 pub struct Union<A, B>(A, B);
 
 /// The `Automaton` state for `Union<A, B>`.
@@ -425,7 +488,6 @@ impl<A: Automaton, B: Automaton> Automaton for Union<A, B> {
 
 /// An automaton that matches when both of its component automata match.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
 pub struct Intersection<A, B>(A, B);
 
 /// The `Automaton` state for `Intersection<A, B>`.
@@ -465,7 +527,6 @@ impl<A: Automaton, B: Automaton> Automaton for Intersection<A, B> {
 
 /// An automaton that matches exactly when the automaton it wraps does not.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
 pub struct Complement<A>(A);
 
 /// The `Automaton` state for `Complement<A>`.

--- a/src/map.rs
+++ b/src/map.rs
@@ -52,6 +52,11 @@ use crate::Result;
 /// around dealing with them (such as a serialization/deserialization step,
 /// although it isn't clear where exactly this should live).
 #[derive(Clone)]
+#[cfg_attr(
+    feature = "epserde",
+    derive(epserde::Epserde),
+    epserde(enforce_repl(D))
+)]
 pub struct Map<D>(raw::Fst<D>);
 
 impl Map<Vec<u8>> {

--- a/src/map.rs
+++ b/src/map.rs
@@ -52,12 +52,8 @@ use crate::Result;
 /// around dealing with them (such as a serialization/deserialization step,
 /// although it isn't clear where exactly this should live).
 #[derive(Clone)]
-#[cfg_attr(
-    feature = "epserde",
-    derive(epserde::Epserde),
-    epserde(enforce_repl(D))
-)]
-pub struct Map<D>(raw::Fst<D>);
+#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
+pub struct Map<D>(#[cfg_attr(feature = "epserde", epserde(force_repl))] raw::Fst<D>);
 
 impl Map<Vec<u8>> {
     /// Create a `Map` from an iterator of lexicographically ordered byte

--- a/src/map.rs
+++ b/src/map.rs
@@ -53,7 +53,7 @@ use crate::Result;
 /// although it isn't clear where exactly this should live).
 #[derive(Clone)]
 #[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
-pub struct Map<D>(#[cfg_attr(feature = "epserde", epserde(force_repl))] raw::Fst<D>);
+pub struct Map<D>(raw::Fst<D>);
 
 impl Map<Vec<u8>> {
     /// Create a `Map` from an iterator of lexicographically ordered byte

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -266,12 +266,14 @@ pub type CompiledAddr = usize;
 /// * [Comparison of Construction Algorithms for Minimal, Acyclic, Deterministic, Finite-State Automata from Sets of Strings](https://www.cs.mun.ca/~harold/Courses/Old/CS4750/Diary/q3p2qx4lv71m5vew.pdf)
 ///   (excellent for surface level overview)
 #[derive(Clone)]
+#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
 pub struct Fst<D> {
     meta: Meta,
     data: D,
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
 struct Meta {
     version: u64,
     root_addr: CompiledAddr,

--- a/src/set.rs
+++ b/src/set.rs
@@ -27,12 +27,8 @@ use crate::Result;
 /// 1. Once constructed, a `Set` can never be modified.
 /// 2. Sets must be constructed with lexicographically ordered byte sequences.
 #[derive(Clone)]
-#[cfg_attr(
-    feature = "epserde",
-    derive(epserde::Epserde),
-    epserde(enforce_repl(D))
-)]
-pub struct Set<D>(raw::Fst<D>);
+#[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
+pub struct Set<D>(#[cfg_attr(feature = "epserde", epserde(force_repl))] raw::Fst<D>);
 
 impl Set<Vec<u8>> {
     /// Create a `Set` from an iterator of lexicographically ordered byte

--- a/src/set.rs
+++ b/src/set.rs
@@ -27,6 +27,11 @@ use crate::Result;
 /// 1. Once constructed, a `Set` can never be modified.
 /// 2. Sets must be constructed with lexicographically ordered byte sequences.
 #[derive(Clone)]
+#[cfg_attr(
+    feature = "epserde",
+    derive(epserde::Epserde),
+    epserde(enforce_repl(D))
+)]
 pub struct Set<D>(raw::Fst<D>);
 
 impl Set<Vec<u8>> {

--- a/src/set.rs
+++ b/src/set.rs
@@ -28,7 +28,7 @@ use crate::Result;
 /// 2. Sets must be constructed with lexicographically ordered byte sequences.
 #[derive(Clone)]
 #[cfg_attr(feature = "epserde", derive(epserde::Epserde))]
-pub struct Set<D>(#[cfg_attr(feature = "epserde", epserde(force_repl))] raw::Fst<D>);
+pub struct Set<D>(raw::Fst<D>);
 
 impl Set<Vec<u8>> {
     /// Create a `Set` from an iterator of lexicographically ordered byte

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -183,3 +183,46 @@ fn implements_default() {
     let set: fst::Set<Vec<u8>> = Default::default();
     assert!(set.is_empty());
 }
+
+#[cfg(feature = "epserde")]
+#[test]
+fn test_epserde() -> Result<(), Box<dyn std::error::Error>> {
+    use epserde::{
+        deser::Deserialize, ser::Serialize, utils::AlignedCursor, Aligned64,
+    };
+    use fst::automaton::{Str, Subsequence};
+
+    // (1) Round-trip the Set on its own.
+    let set = get_set();
+    let mut cursor = <AlignedCursor<Aligned64>>::new();
+    unsafe { set.serialize(&mut cursor)? };
+    let mmapd_set =
+        unsafe { <Set<Vec<u8>>>::deserialize_eps(cursor.as_bytes())? };
+    assert_eq!(set.len(), mmapd_set.len());
+
+    let mut stream = set.stream();
+    while let Some(key) = stream.next() {
+        assert!(mmapd_set.contains(key));
+    }
+
+    // (2) Build a composite automaton (Union<Str, Subsequence>) and round-trip
+    // it. This exercises every layer of the Epserde derives: a combinator on
+    // top of two different leaf automata, each holding a borrowed slice.
+    let automaton = Str::new("foo").union(Subsequence::new("od"));
+    let mut acursor = <AlignedCursor<Aligned64>>::new();
+    unsafe { automaton.serialize(&mut acursor)? };
+    let mmapd_automaton = unsafe {
+        <fst::automaton::Union<Str, Subsequence>>::deserialize_eps(
+            acursor.as_bytes(),
+        )?
+    };
+
+    // (3) Search the deserialized Set with the deserialized automaton and
+    // compare results to running the originals against each other.
+    let hits =
+        mmapd_set.search(&mmapd_automaton).into_stream().into_strs()?;
+    let expected = set.search(&automaton).into_stream().into_strs()?;
+    assert_eq!(hits, expected);
+
+    Ok(())
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -224,5 +224,24 @@ fn test_epserde() -> Result<(), Box<dyn std::error::Error>> {
     let expected = set.search(&automaton).into_stream().into_strs()?;
     assert_eq!(hits, expected);
 
+    // (4) Round-trip a Levenshtein automaton, which carries owned DFA tables
+    // (`Vec<State>` with `[Option<usize>; 256]` transition arrays). Confirms
+    // that owned-heap leaves compose through epserde the same way borrowed
+    // leaves do.
+    #[cfg(feature = "levenshtein")]
+    {
+        use fst::automaton::Levenshtein;
+        let lev = Levenshtein::new("foo", 1)?;
+        let mut lcursor = <AlignedCursor<Aligned64>>::new();
+        unsafe { lev.serialize(&mut lcursor)? };
+        let mmapd_lev = unsafe {
+            <Levenshtein>::deserialize_eps(lcursor.as_bytes())?
+        };
+        let lev_hits =
+            mmapd_set.search(&mmapd_lev).into_stream().into_strs()?;
+        let lev_expected = set.search(&lev).into_stream().into_strs()?;
+        assert_eq!(lev_hits, lev_expected);
+    }
+
     Ok(())
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -219,8 +219,7 @@ fn test_epserde() -> Result<(), Box<dyn std::error::Error>> {
 
     // (3) Search the deserialized Set with the deserialized automaton and
     // compare results to running the originals against each other.
-    let hits =
-        mmapd_set.search(&mmapd_automaton).into_stream().into_strs()?;
+    let hits = mmapd_set.search(&mmapd_automaton).into_stream().into_strs()?;
     let expected = set.search(&automaton).into_stream().into_strs()?;
     assert_eq!(hits, expected);
 
@@ -234,9 +233,8 @@ fn test_epserde() -> Result<(), Box<dyn std::error::Error>> {
         let lev = Levenshtein::new("foo", 1)?;
         let mut lcursor = <AlignedCursor<Aligned64>>::new();
         unsafe { lev.serialize(&mut lcursor)? };
-        let mmapd_lev = unsafe {
-            <Levenshtein>::deserialize_eps(lcursor.as_bytes())?
-        };
+        let mmapd_lev =
+            unsafe { <Levenshtein>::deserialize_eps(lcursor.as_bytes())? };
         let lev_hits =
             mmapd_set.search(&mmapd_lev).into_stream().into_strs()?;
         let lev_expected = set.search(&lev).into_stream().into_strs()?;


### PR DESCRIPTION
This PR adds gated [ε-serde](http://crates.io/crates/epserde) support to `fst`. There is no change in the `fst` code—just a few gated derives and implementations.

ε-serde tries to solve in general the problem `fst` solves specifically for memory-mapping large amount of data, but it does it using derive macros for generic data structures; it replaces recursively vectors or boxed slices with reference to a byte buffer (e.g., memory-mapped) and strings with references to `str`.

The additional feature gained by `fst` is the possibility of serializing and map into memory directly any hierarchical combination of types, not just leaves (there are a few examples and the end of `test.rs`.

`fst` was in fact the trigger for expanding the scope of ε-serde: originally, we were just replacing type parameters which where the type of a field; now, we replace them recursively everywhere (which turned out to be fairly complicated).

This PR does not modify any `fst` code, but because of that it needs to provide hand-made serialization/deserialization implementations for the leaves (`Str`, `Subsequence`) because we can only support memory mapping, and not full deserialization.

We are also proposing another PR that just uses gated derives, but in this case we need to add a parameter to `Str` and `Subsequence`, so that it can be substituted. We gain full deserialization, which is of interest as ε-serde can fully deserialize into transparent huge pages, which might provide some performance boost. But this requires a small incompatible change to the exposed API.